### PR TITLE
Replace Prop drilling with useContext pattern for access to state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,7 +59,7 @@ function App() {
                             />
                             <Route
                                 path="/viewer"
-                                element={<ModelViewPage curentModelPath={viewerState.currentModelPath} />}
+                                element={<ModelViewPage />}
                             />
                         </Routes>
                     </div>

--- a/src/components/Components/SceneTreeItem.tsx
+++ b/src/components/Components/SceneTreeItem.tsx
@@ -7,7 +7,6 @@ import TreeItem, {
 } from '@mui/lab/TreeItem';
 import clsx from 'clsx';
 import Typography from '@mui/material/Typography';
-import { modelUIState } from '../../state/ModelUIState';
 
 const CustomContent = React.forwardRef(function CustomContent(
     props: TreeItemContentProps,
@@ -34,7 +33,6 @@ const CustomContent = React.forwardRef(function CustomContent(
     } = useTreeItem(nodeId);
 
     const icon = iconProp || expansionIcon || displayIcon;
-    const nodeUuid = nodeId;
 
     const handleMouseDown = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
       preventSelection(event);
@@ -50,7 +48,6 @@ const CustomContent = React.forwardRef(function CustomContent(
       event: React.MouseEvent<HTMLDivElement, MouseEvent>,
     ) => {
       handleSelection(event);
-      modelUIState.setSelected(nodeUuid);
     };
 
     return (

--- a/src/components/Components/SceneTreeView.tsx
+++ b/src/components/Components/SceneTreeView.tsx
@@ -50,12 +50,12 @@ const SceneTreeView  = ()  => {
       curState.setSelected(node as string);
     }
     const sTree = curState.sceneTree
-    if (sTree === null) {
+    if (sTree === null && curState.scene !== null) {
       // console.log(curState.scene);
       curState.setSceneTree(new SceneTreeModel(curState.scene!));
     }
-    const meshesNode = sTree?.rootNode?.children[0]
-    const meshesArray = meshesNode?.children;
+    const meshesNode = (sTree === null)? null: sTree.rootNode?.children[0]
+    const meshesArray = (sTree === null)? null: meshesNode?.children;
     return (
         <TreeView
             aria-label="file system navigator"

--- a/src/components/Components/SceneTreeView.tsx
+++ b/src/components/Components/SceneTreeView.tsx
@@ -1,8 +1,9 @@
 import TreeView from '@mui/lab/TreeView'; 
-import { modelUIState } from "../../state/ModelUIState";
 import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
 import SceneTreeItem from './SceneTreeItem';
-import { TreeNode } from '../../helpers/SceneTreeModel';
+import SceneTreeModel, { TreeNode } from '../../helpers/SceneTreeModel';
+import { observer } from 'mobx-react';
+import { useModelContext } from '../../state/ModelUIStateContext';
 
 function MinusSquare(props: SvgIconProps) {
     return (
@@ -37,13 +38,22 @@ function MinusSquare(props: SvgIconProps) {
   }
 
 const SceneTreeView  = ()  => {
+  const curState = useModelContext();
     function createTreeItemForNode(anode: TreeNode, index: number) {
         let computeId = (3+index);
         let threeObj = anode.threeObject;
         //console.log(threeObj);
         return <SceneTreeItem nodeId={threeObj!.uuid} label={anode.name} key={computeId} />
     }
-    const sTree = modelUIState.sceneTree
+    const handleSelect = async (event: any, node: any) => {
+      //console.log('nodeId: ', node)
+      curState.setSelected(node as string);
+    }
+    const sTree = curState.sceneTree
+    if (sTree === null) {
+      // console.log(curState.scene);
+      curState.setSceneTree(new SceneTreeModel(curState.scene!));
+    }
     const meshesNode = sTree?.rootNode?.children[0]
     const meshesArray = meshesNode?.children;
     return (
@@ -53,6 +63,8 @@ const SceneTreeView  = ()  => {
             defaultCollapseIcon={<MinusSquare />}
             defaultExpandIcon={<PlusSquare />}
             defaultEndIcon={<CloseSquare />}
+            onNodeSelect={handleSelect}
+            selected={curState.selected}
         >
             <SceneTreeItem  nodeId="1" label={sTree?.rootNode?.name} key={1} >
                 <SceneTreeItem  nodeId="2" label={sTree?.rootNode?.children[0].name} key={2}>
@@ -63,4 +75,4 @@ const SceneTreeView  = ()  => {
     );
 }
 
-export default SceneTreeView;
+export default observer(SceneTreeView);

--- a/src/components/Components/VisualizationControl.tsx
+++ b/src/components/Components/VisualizationControl.tsx
@@ -5,8 +5,8 @@ import PlayCircleTwoToneIcon from '@mui/icons-material/PlayCircleTwoTone';
 import { useTranslation } from 'react-i18next';
 import { useState } from 'react';
 import InputLabel from '@mui/material/InputLabel';
-import { modelUIState } from '../../state/ModelUIState';
 import { AnimationClip } from 'three';
+import { useModelContext } from '../../state/ModelUIStateContext';
 
 interface VisualizationControlProps {
     animating?: boolean;
@@ -18,12 +18,13 @@ interface VisualizationControlProps {
 }
 
 function AnimationsMenu (props:VisualizationControlProps) {
+    const curState = useModelContext();
     const handleAnimationChange = (event: SelectChangeEvent) => {
         if (event.target.value as string === ""){
-            modelUIState.setAnimating(false)
+            curState.setAnimating(false)
         }
         else {
-            modelUIState.setAnimating(true)
+            curState.setAnimating(true)
         }
         //setAge(event.target.value as string);
     };
@@ -48,14 +49,15 @@ const VisualizationControl : React.FC<VisualizationControlProps> = (props:Visual
     const { t } = useTranslation();
     const [play, setPlay] = useState(false);
     const [speed, setSpeed] = useState(1.0);
+    const curState = useModelContext();
     // console.log("Props", props);
     function togglePlayAnimation() {
-        modelUIState.setAnimating(!modelUIState.animating);
+        curState.setAnimating(!curState.animating);
         setPlay(!play);
 
     }
     function handleSpeedChange(event: SelectChangeEvent) {
-         modelUIState.setAnimationSpeed(Number(event.target.value));
+        curState.setAnimationSpeed(Number(event.target.value));
          setSpeed(Number(event.target.value))
    }
     return (
@@ -63,8 +65,8 @@ const VisualizationControl : React.FC<VisualizationControlProps> = (props:Visual
       <Container disableGutters>
         <FormGroup>
             <Typography variant="h6" align='left'>{t('Visibility')}</Typography>
-            <FormControlLabel control={<Checkbox checked={modelUIState.showGlobalFrame}/>} label="WCS" 
-                    onClick={()=>modelUIState.setShowGlobalFrame(!modelUIState.showGlobalFrame)}/>
+            <FormControlLabel control={<Checkbox checked={curState.showGlobalFrame}/>} label="WCS" 
+                    onClick={()=>curState.setShowGlobalFrame(!curState.showGlobalFrame)}/>
             <FormControlLabel control={<Checkbox />} label="Joints" />
             <FormControlLabel control={<Checkbox />} label="Bodies" />
             <FormControlLabel control={<Checkbox />} label="Markers" />

--- a/src/components/Nav/LeftDrawer.tsx
+++ b/src/components/Nav/LeftDrawer.tsx
@@ -94,7 +94,7 @@ export function PersistentDrawerLeft() {
   const [tabValue, setTabValue] = React.useState('0');
   const curState = useModelContext();
   curState.setCurrentModelPath(viewerState.currentModelPath);
-  const [uiState, setUIState] = React.useState<ModelUIState>(curState);
+  const [uiState] = React.useState<ModelUIState>(curState);
 
   const handleDrawerOpen = () => {
     setOpen(true);

--- a/src/components/Nav/LeftDrawer.tsx
+++ b/src/components/Nav/LeftDrawer.tsx
@@ -30,8 +30,10 @@ import { Tab } from '@mui/material';
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import OpenSimScene from '../pages/OpenSimScene';
 import VisualizationControl from '../Components/VisualizationControl';
-import { modelUIState } from '../../state/ModelUIState';
+import { ModelUIState } from '../../state/ModelUIState';
 import { observer } from 'mobx-react';
+import { MyModelContext } from '../../state/ModelUIStateContext';
+import { useModelContext } from '../../state/ModelUIStateContext';
 
 
 const drawerWidth = 240;
@@ -90,6 +92,9 @@ export function PersistentDrawerLeft() {
   const theme = useTheme();
   const [open, setOpen] = React.useState(false);
   const [tabValue, setTabValue] = React.useState('0');
+  const curState = useModelContext();
+  curState.setCurrentModelPath(viewerState.currentModelPath);
+  const [uiState, setUIState] = React.useState<ModelUIState>(curState);
 
   const handleDrawerOpen = () => {
     setOpen(true);
@@ -104,6 +109,7 @@ export function PersistentDrawerLeft() {
   };
 
   return (
+    <MyModelContext.Provider value = {uiState}>
     <Box component="div" sx={{ display: 'flex' }}>
       <CssBaseline />
       <AppBar position="fixed" open={open}>
@@ -168,8 +174,8 @@ export function PersistentDrawerLeft() {
         </TabPanel>
         <TabPanel value="1" tabIndex={1}>
           <VisualizationControl animationPlaySpeed={1.0} 
-                                animating={modelUIState.animating}
-                                animationList={modelUIState.animations}/>
+                                animating={uiState.animating}
+                                animationList={uiState.animations}/>
           </TabPanel>
         </TabContext>
       </Drawer>
@@ -191,13 +197,14 @@ export function PersistentDrawerLeft() {
                         <GizmoViewport labelColor="white" axisHeadScale={1} />
                     </GizmoHelper>
                     <OpenSimControl />
-                    <axesHelper visible={modelUIState.showGlobalFrame} args={[20]} />
+                    <axesHelper visible={uiState.showGlobalFrame} args={[20]} />
             </Canvas>
             </Suspense>
             <BottomBar />
             </div>
       </Main>
     </Box>
+    </MyModelContext.Provider>
   );
 }
 

--- a/src/components/pages/BottomBar.tsx
+++ b/src/components/pages/BottomBar.tsx
@@ -9,10 +9,12 @@ import VideoCameraFrontTwoToneIcon from '@mui/icons-material/VideoCameraFrontTwo
 import Tooltip from '@mui/material/Tooltip';
 import { observer } from 'mobx-react'
 import { useTranslation } from 'react-i18next'
-import { modelUIState } from '../../state/ModelUIState'
+import { useModelContext } from '../../state/ModelUIStateContext';
+
 
 function BottomBar() {
     const { t } = useTranslation();
+    const curState = useModelContext();
 
     return (
         <Container style={{height: '7vh' }}>
@@ -20,23 +22,23 @@ function BottomBar() {
                 <Tooltip title={t('bottomBar.autoRotate')}>
                     <ToggleButton
                         color="primary"
-                        selected={modelUIState.rotating}
+                        selected={curState.rotating}
                         value={'Rotate'}
-                        onClick={() => modelUIState.setRotating(!modelUIState.rotating)}>
+                        onClick={() => curState.setRotating(!curState.rotating)}>
                         <ThreeSixtyTwoToneIcon />
                     </ToggleButton>
                 </Tooltip>
                 <Tooltip title={t('bottomBar.zoomIn')}>
                     <IconButton color="primary" onClick={() => {
-                        modelUIState.setZoomFactor(1.1); 
-                        modelUIState.setZooming(true)}}>
+                        curState.setZoomFactor(1.1); 
+                        curState.setZooming(true)}}>
                         <ZoomInTwoToneIcon />
                     </IconButton>
                 </Tooltip>
                 <Tooltip title={t('bottomBar.zoomOut')}>
                     <IconButton color="primary" onClick={() => {
-                        modelUIState.setZoomFactor(0.9); 
-                        modelUIState.setZooming(true)}}>
+                        curState.setZoomFactor(0.9); 
+                        curState.setZooming(true)}}>
                         <ZoomOutTwoToneIcon />
                     </IconButton>
                 </Tooltip>
@@ -52,7 +54,7 @@ function BottomBar() {
                 </Tooltip>
                 <Tooltip title={t('bottomBar.snapshoot')}>
                     <IconButton color="primary" onClick={() => {
-                        modelUIState.setTakeSnapshot();}}>
+                        curState.setTakeSnapshot();}}>
                         <PhotoCameraTwoToneIcon />
                     </IconButton>
                 </Tooltip>

--- a/src/components/pages/ModelViewPage.tsx
+++ b/src/components/pages/ModelViewPage.tsx
@@ -1,14 +1,6 @@
-import { useTheme } from '@mui/material'
-
 import LeftDrawer from '../Nav/LeftDrawer'
 
-interface ModelViewPageProps {
-    curentModelPath: string
-}
-
-const ModelViewPage: React.FC<ModelViewPageProps> = ({ curentModelPath }) => {
-    const theme = useTheme()
-    console.log(theme.palette.mode)
+const ModelViewPage: React.FC<{}> = () => {
 
     return (
         <LeftDrawer />

--- a/src/components/pages/OpenSimControl.tsx
+++ b/src/components/pages/OpenSimControl.tsx
@@ -1,6 +1,7 @@
 import { OrbitControls, CameraControls } from '@react-three/drei'
 import { observer } from 'mobx-react'
-import { modelUIState } from '../../state/ModelUIState'
+import { useModelContext } from '../../state/ModelUIStateContext';
+
 import { useFrame, useThree } from '@react-three/fiber'
 import { Ref, useRef } from 'react'
 
@@ -11,26 +12,27 @@ const OpenSimControl = () => {
     } = useThree()
 
     const ref = useRef<CameraControls>();
+    const curState = useModelContext();
 
     useFrame((_, delta) => {
-        if (modelUIState.zooming){
+        if (curState.zooming){
             console.log(delta)
-            let zoomFactor = modelUIState.zoom_inOut;
+            let zoomFactor = curState.zoom_inOut;
             camera.zoom *= zoomFactor;
             camera.updateProjectionMatrix();
-            modelUIState.zooming = false;
+            curState.zooming = false;
         }
-        else if (modelUIState.takeSnapshot){
+        else if (curState.takeSnapshot){
             const link = document.createElement('a')
             link.setAttribute('download', 'viewer_snapshot.png')
             link.setAttribute('href', gl.domElement.toDataURL('image/png').replace('image/png', 'image/octet-stream'))
             link.click()
-            modelUIState.takeSnapshot = false;
+            curState.takeSnapshot = false;
         }
       })
     //console.log(viewerState.rotating);
     return <>
-        <OrbitControls autoRotate autoRotateSpeed={modelUIState.rotating ? 2 : 0.0} makeDefault  />
+        <OrbitControls autoRotate autoRotateSpeed={curState.rotating ? 2 : 0.0} makeDefault  />
         <CameraControls enabled={false} ref={(ref as unknown) as Ref<CameraControls> | undefined}/>
     </>
 }

--- a/src/components/pages/OpenSimScene.tsx
+++ b/src/components/pages/OpenSimScene.tsx
@@ -26,7 +26,7 @@ const OpenSimScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, supportCo
           uuid2ObjectMap.set(o.uuid, o)
           if (o.type === "Mesh") {
             let helper : BoxHelper = new BoxHelper(o)
-            console.log("add helper for ", o.name);
+            //console.log("add helper for ", o.name);
             uuid2SelectionMap.set(o.uuid, helper);
             helper.visible = false;
             scene.add(helper);

--- a/src/components/pages/OpenSimScene.tsx
+++ b/src/components/pages/OpenSimScene.tsx
@@ -1,11 +1,11 @@
 import { useGLTF } from '@react-three/drei'
 import { useFrame } from '@react-three/fiber'
 
-import { useEffect, useRef } from 'react'
-import { AnimationMixer, BoxHelper, Object3D, Scene } from 'three'
+import { useEffect } from 'react'
+import { AnimationMixer, BoxHelper, Object3D } from 'three'
 
 import SceneTreeModel from '../../helpers/SceneTreeModel'
-import { modelUIState } from '../../state/ModelUIState'
+import { useModelContext } from '../../state/ModelUIStateContext'
 
 interface OpenSimSceneProps {
     currentModelPath: string,
@@ -14,17 +14,19 @@ interface OpenSimSceneProps {
 
 const OpenSimScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, supportControls }) => {
 
-    const sceneRef = useRef<Scene>(null!)
     // useGLTF suspends the component, it literally stops processing
     const { scene, animations } = useGLTF(currentModelPath);
     // eslint-disable-next-line no-mixed-operators
     let uuid2ObjectMap = new Map<string, Object3D>();
     let uuid2SelectionMap = new Map<string, BoxHelper>();
+    let curState = useModelContext();
+    curState.scene = scene;
     if (supportControls) {
       scene.traverse((o) => {
           uuid2ObjectMap.set(o.uuid, o)
           if (o.type === "Mesh") {
             let helper : BoxHelper = new BoxHelper(o)
+            console.log("add helper for ", o.name);
             uuid2SelectionMap.set(o.uuid, helper);
             helper.visible = false;
             scene.add(helper);
@@ -41,37 +43,37 @@ const OpenSimScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, supportCo
         });
     }
     useFrame((state, delta) => {
-      if (modelUIState !== undefined) {
+      if (curState !== undefined) {
         if (supportControls ) {
-          if (modelUIState.deSelected!==""){
-            let deselectedBox = uuid2SelectionMap.get(modelUIState.deSelected)
+          if (curState.deSelected!==""){
+            let deselectedBox = uuid2SelectionMap.get(curState.deSelected)
             if (deselectedBox !== undefined) {
               deselectedBox.visible = false;
             }
           }
-          let selectedObject = uuid2ObjectMap.get(modelUIState.selected)!
+          let selectedObject = uuid2ObjectMap.get(curState.selected)!
           if (selectedObject !== undefined && selectedObject.type === "Mesh") {
-            uuid2SelectionMap.get(modelUIState.selected)!.visible = true
+            uuid2SelectionMap.get(curState.selected)!.visible = true
           }
         }
-        if (supportControls && modelUIState.animating){
-            mixer?.update(delta * modelUIState.animationSpeed)
+        if (supportControls && curState.animating){
+            mixer?.update(delta * curState.animationSpeed)
         }
       }
     })
 
     useEffect(() => {
         if (supportControls) {
-            modelUIState.setCurrentModelPath(currentModelPath)
-            modelUIState.setSceneTree(new SceneTreeModel(sceneRef.current))
-            modelUIState.setAnimationList(animations)
+            curState.setCurrentModelPath(currentModelPath)
+            curState.setSceneTree(new SceneTreeModel(scene))
+            curState.setAnimationList(animations)
         }
-      }, [scene, animations, supportControls, currentModelPath])
+      }, [scene, animations, supportControls, currentModelPath, curState])
 
     // By the time we're here the model is guaranteed to be available
-    return <primitive ref={sceneRef} object={scene} 
-      onPointerDown={(e: any) => modelUIState.setSelected(e.object.uuid)}
-      onPointerMissed={() => modelUIState.setSelected("")}/>
+    return <primitive object={scene} 
+      onPointerDown={(e: any) => curState.setSelected(e.object.uuid)}
+      onPointerMissed={() => curState.setSelected("")}/>
 }
 
 export default OpenSimScene

--- a/src/components/pages/OpenSimScene.tsx
+++ b/src/components/pages/OpenSimScene.tsx
@@ -71,7 +71,7 @@ const OpenSimScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, supportCo
         }
         return () => {
           sceneObjectSelectionMap.forEach((value)=>{
-            return value.removeFromParent();
+            return scene.remove(value)
           });
           sceneObjectSelectionMap.clear();
           sceneObjectMap.clear();

--- a/src/helpers/SceneTreeModel.tsx
+++ b/src/helpers/SceneTreeModel.tsx
@@ -1,4 +1,4 @@
-import { Object3D, Scene } from "three"; 
+import { Object3D, Group } from "three"; 
 
 export class TreeNode 
 {
@@ -22,7 +22,7 @@ export class TreeNode
 class SceneTreeModel
 {
     public rootNode: TreeNode|null;
-    constructor(sceneTreeGroup: Scene)
+    constructor(sceneTreeGroup: Group)
     {
         this.rootNode = new TreeNode(null, sceneTreeGroup);
         this.rootNode.setName(sceneTreeGroup.name)

--- a/src/state/ModelUIState.tsx
+++ b/src/state/ModelUIState.tsx
@@ -1,9 +1,11 @@
 import { makeObservable, observable, action } from 'mobx'
 import SceneTreeModel from '../helpers/SceneTreeModel'
 import { AnimationClip } from 'three/src/animation/AnimationClip'
+import { Group } from 'three'
 
 export class ModelUIState {
     currentModelPath: string
+    scene: Group | null
     rotating: boolean
     zooming: boolean
     zoom_inOut: number
@@ -21,6 +23,7 @@ export class ModelUIState {
         rotatingState: boolean,
     ) {
         this.currentModelPath = currentModelPathState
+        this.scene = null
         this.rotating = rotatingState
         this.zooming = false
         this.zoom_inOut = 0.0
@@ -44,12 +47,19 @@ export class ModelUIState {
             animationSpeed: observable,
             setAnimationSpeed: action,
             selected: observable,
+            setSelected: action,
+            sceneTree: observable,
+            setSceneTree: action
         })
         console.log("Created ModelUIState instance ", currentModelPathState)
     }
 
     setCurrentModelPath(newState: string) {
-        this.currentModelPath = newState
+        let oldPath = this.currentModelPath
+        if (oldPath !== newState){
+            this.currentModelPath = newState
+            this.sceneTree = null;
+        }
     }
     setRotating(newState: boolean) {
         this.rotating = newState
@@ -84,5 +94,3 @@ export class ModelUIState {
     }
 
 }
-
-export let modelUIState = new ModelUIState('', false);

--- a/src/state/ModelUIStateContext.tsx
+++ b/src/state/ModelUIStateContext.tsx
@@ -1,0 +1,5 @@
+import { createContext, useContext } from "react"
+import { ModelUIState } from "./ModelUIState"
+
+export const MyModelContext = createContext<ModelUIState>(new ModelUIState('', false))
+export const useModelContext = () => useContext(MyModelContext)


### PR DESCRIPTION
This PR refactors state management for the viewer components by making them share a state using the "useContext" /"ContextProvider" pattern so we don't pass loads of properties down the tree of components. This also fixes the issue where graphical and tree selection are out of sync. 