### PR TITLE
Fix issues where muscles disappear on zoom

### DIFF
--- a/src/components/pages/OpenSimScene.tsx
+++ b/src/components/pages/OpenSimScene.tsx
@@ -2,7 +2,7 @@ import { useGLTF } from '@react-three/drei'
 import { useFrame } from '@react-three/fiber'
 
 import { useEffect, useState } from 'react'
-import { AnimationMixer, BoxHelper, Object3D } from 'three'
+import { AnimationMixer, BoxHelper, Group, Object3D } from 'three'
 
 import SceneTreeModel from '../../helpers/SceneTreeModel'
 import { useModelContext } from '../../state/ModelUIStateContext'
@@ -16,6 +16,16 @@ const OpenSimScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, supportCo
 
     // useGLTF suspends the component, it literally stops processing
     const { scene, animations } = useGLTF(currentModelPath);
+    const no_face_cull = (scene: Group)=>{
+      if (scene) {
+        scene.traverse((o)=>{
+          if (o.name.endsWith("geometrypath")){
+            o.frustumCulled = false;
+          }
+        })
+      }
+    };
+    no_face_cull(scene);
     // eslint-disable-next-line no-mixed-operators
     const [sceneObjectMap] = useState<Map<string, Object3D>>(new Map<string, Object3D>());
     const [objectSelectionBox, setObjectSelectionBox] = useState<BoxHelper | null>(new BoxHelper(scene));


### PR DESCRIPTION
This is a work around frustum culling not computing bbox for muscles correctly causing them to be culled out when origin is not in view frustum. With this PR zooming on models with muscles work as expected (same workaround is implemented in opensim gui(