### PR TITLE
Fix bug where animations don't play on model upload/switch

### DIFF
--- a/src/components/pages/OpenSimScene.tsx
+++ b/src/components/pages/OpenSimScene.tsx
@@ -76,8 +76,10 @@ const OpenSimScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, supportCo
         scene.add(objectSelectionBox!);
       }
     }
-    // This is a hack we need to make sure mixers match animations not just count
-    if (animations.length > 0 && mixers.length !==animations.length ) {
+    // Make sure mixers match animations
+    if ((animations.length > 0 && mixers.length !==animations.length) ||
+        (animations.length > 0 && mixers.length > 0 && mixers[0].getRoot() !== scene)) {
+        mixers.length = 0
         animations.forEach((clip) => {
             const nextMixer = new AnimationMixer(scene)
             nextMixer.clipAction(clip, scene)


### PR DESCRIPTION
Fix test to decide if animations list needs to be updated which was causing animations to match wrong model thus failing to play.