### PR TITLE
Support45 path handling

### DIFF
--- a/ExamplePageIFrame.html
+++ b/ExamplePageIFrame.html
@@ -6,9 +6,9 @@
     <title>Model Viewer Embedded</title>
 </head>
 <body>
-    <iframe src="http://localhost:3000/embed-viewer/%2Fbuiltin%2Farm26.gltf" width="700" height="700" >
+    <iframe src="https://master.d7iaa9a9lxtm6.amplifyapp.com/viewer/https%3A%2F%2Fs3.us-west-2.amazonaws.com%2Fopensim-viewer-public-download%2Fsubject01_simbody.gltf" width="700" height="700" >
     </iframe>
 </body>
-<h3>This refers to a local server but will refer to public once this branch is deployed!</h3>
+<h3>This refers to the aws public deploy!</h3>
 <a href="https://simtk-confluence.stanford.edu:8443/display/OpenSim/Musculoskeletal+Models" target="_blank"> Model info</a>
 </html>

--- a/src/components/pages/ModelViewPage.tsx
+++ b/src/components/pages/ModelViewPage.tsx
@@ -114,7 +114,7 @@ export function ModelViewPage({url, embedded, noFloor}:ViewerProps) {
                 }}
                 camera={{ position: [1500, 2000, 1000], fov: 75, far: 10000 }}
               >
-                <fog attach="fog" color="lightgray" near={1} far={10} />
+                <fog attach="fog" color="lightgray" near={1} far={10000} />
                 <color
                   attach="background"
                   args={

--- a/src/components/pages/OpenSimScene.tsx
+++ b/src/components/pages/OpenSimScene.tsx
@@ -19,7 +19,7 @@ const OpenSimScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, supportCo
     const no_face_cull = (scene: Group)=>{
       if (scene) {
         scene.traverse((o)=>{
-          if (o.name.endsWith("geometrypath")){
+          if (o.name.endsWith("path")){
             o.frustumCulled = false;
           }
           mapObjectToLayer(o)


### PR DESCRIPTION
While we don't support muscles explicitly, path objects still exist in gltf format. This PR updates viewer codebase to follow 4.5 forrmat where geometrypath components are renamed to path