### PR TITLE
Select camera

### DIFF
--- a/src/components/pages/BottomBar.tsx
+++ b/src/components/pages/BottomBar.tsx
@@ -127,7 +127,7 @@ const BottomBar = React.forwardRef(function CustomContent(
         setSelectedCam(curState.cameras[0].name)
         handleCameraChange(curState.cameras[0].name)
       }
-    }, [curState.cameras]);
+    }, [curState.cameras, handleCameraChange]);
 
     return (
       <Container ref={(ref as any) || bottomBarRef}>

--- a/src/components/pages/BottomBar.tsx
+++ b/src/components/pages/BottomBar.tsx
@@ -10,6 +10,7 @@ import { observer } from 'mobx-react'
 import { AnimationClip } from 'three';
 import { useTranslation } from 'react-i18next';
 import { useModelContext } from '../../state/ModelUIStateContext';
+import { Camera } from 'three/src/cameras/Camera'
 import React, { useCallback, useRef } from 'react';
 
 const NonAnimatedSlider = styled(Slider)(({ theme } : {theme:any}) => ({
@@ -39,6 +40,7 @@ const BottomBar = React.forwardRef(function CustomContent(
     const [speed, setSpeed] = useState(1.0);
     const [play, setPlay] = useState(false);
     const [selectedAnim, setSelectedAnim] = useState<string | undefined>("");
+    const [selectedCam, setSelectedCam] = useState<string | undefined>("");
 
     const isExtraSmallScreen = useMediaQuery((theme:any) => theme.breakpoints.only('xs'));
     const isSmallScreen = useMediaQuery((theme:any) => theme.breakpoints.only('sm'));
@@ -46,6 +48,7 @@ const BottomBar = React.forwardRef(function CustomContent(
 
     const minWidthSlider = isExtraSmallScreen ? 150 : isSmallScreen ? 175 : isMediumScreen ? 250 : 300; // Adjust values as needed
     const maxWidthTime = 45;
+
 
     const handleAnimationChange = useCallback((animationName: string, animate: boolean) => {
       const targetName = animationName
@@ -63,9 +66,27 @@ const BottomBar = React.forwardRef(function CustomContent(
       //setAge(event.target.value as string);
     }, [curState]);
 
+    const handleCameraChange = useCallback((cameraName: string) => {
+      const targetName = cameraName
+      setSelectedCam(cameraName);
+
+        const idx = curState.cameras.findIndex((value: Camera, index: number)=>{return (value.name === targetName)})
+        if (idx !== -1) {
+            curState.setCurrentCameraIndex(idx)
+        }
+
+      curState.setCurrentFrame(0);
+      //setAge(event.target.value as string);
+    }, [curState]);
+
     const handleAnimationChangeEvent = (event: SelectChangeEvent) => {
       const targetName = event.target.value as string
       handleAnimationChange(targetName, true)
+    };
+
+    const handleCameraChangeEvent = (event: SelectChangeEvent) => {
+      const targetName = event.target.value as string
+      handleCameraChange(targetName)
     };
 
     function togglePlayAnimation() {
@@ -101,11 +122,19 @@ const BottomBar = React.forwardRef(function CustomContent(
       }
     }, [curState.animations, handleAnimationChange]);
 
+    useEffect(() => {
+      if (curState.cameras.length > 0) {
+        setSelectedCam(curState.cameras[0].name)
+        handleCameraChange(curState.cameras[0].name)
+      }
+    }, [curState.cameras]);
+
     return (
       <Container ref={(ref as any) || bottomBarRef}>
 
         <Grid container spacing={1} justifyContent="center">
 
+          { curState.animations.length < 1 ? null : (
           <Grid item>
             <FormControl margin="dense" size="small" variant="standard" sx={{maxWidth: 100 }}>
               <Select
@@ -122,6 +151,27 @@ const BottomBar = React.forwardRef(function CustomContent(
               </Select>
             </FormControl>
           </Grid>
+          )}
+
+          { curState.cameras.length < 1 ? null : (
+          <Grid item>
+            <FormControl margin="dense" size="small" variant="standard" sx={{maxWidth: 100 }}>
+              <Select
+                labelId="simple-select-standard-label"
+                label={t('visualizationControl.camera')}
+                value={selectedCam?.toString()}
+                onChange={handleCameraChangeEvent}
+                disabled={curState.cameras.length < 1}>
+                  {curState.cameras.map(cam => (
+                    <MenuItem key={cam.name} value={cam.name}>
+                      {cam.name}
+                    </MenuItem>
+                  ))}
+                visibility={false}
+              </Select>
+            </FormControl>
+          </Grid>
+          )}
 
           <Grid item>
             <FormControl margin="dense" size="small" variant="standard">

--- a/src/components/pages/ModelViewPage.tsx
+++ b/src/components/pages/ModelViewPage.tsx
@@ -81,6 +81,8 @@ export function ModelViewPage({url, embedded, noFloor}:ViewerProps) {
       const heightBottomBar = bottomBarRef.current.offsetHeight;
       setHeightBottomBar(bottomBarRef.current.offsetHeight);
 
+      setCanvasHeight("calc(100vh - 68px - " + heightBottomBar + "px)");
+
       // Do something with heightBottomBar if needed
       console.log('Height of BottomBar:', heightBottomBar);
     }

--- a/src/components/pages/OpenSimScene.tsx
+++ b/src/components/pages/OpenSimScene.tsx
@@ -1,11 +1,14 @@
 import { useGLTF } from '@react-three/drei'
-import { useFrame } from '@react-three/fiber'
+import { useFrame, useThree } from '@react-three/fiber'
 
 import { useEffect, useState } from 'react'
 import { AnimationMixer, BoxHelper, Group, Object3D } from 'three'
+import { observer } from 'mobx-react'
 
 import SceneTreeModel from '../../helpers/SceneTreeModel'
 import { useModelContext } from '../../state/ModelUIStateContext'
+import { Camera } from 'three/src/cameras/Camera'
+import { PerspectiveCamera } from 'three/src/cameras/PerspectiveCamera'
 
 interface OpenSimSceneProps {
     currentModelPath: string,
@@ -16,6 +19,7 @@ const OpenSimScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, supportCo
 
     // useGLTF suspends the component, it literally stops processing
     const { scene, animations } = useGLTF(currentModelPath);
+    const { set, camera, gl } = useThree();
     const no_face_cull = (scene: Group)=>{
       if (scene) {
         scene.traverse((o)=>{
@@ -23,10 +27,11 @@ const OpenSimScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, supportCo
             o.frustumCulled = false;
           }
           mapObjectToLayer(o)
-          
+
         })
       }
     };
+
     const LayerMap = new Map([
       ["Mesh", 1],
       ["Force", 2],
@@ -65,6 +70,40 @@ const OpenSimScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, supportCo
     const [mixers, ] = useState<AnimationMixer[]>([])
     let curState = useModelContext();
     curState.scene = scene;
+
+    const [currentCamera, setCurrentCamera] = useState<PerspectiveCamera>()
+
+
+    // This useEffect loads the cameras and assign them to its respective states.
+    useEffect(() => {
+      const cameras = scene.getObjectsByProperty( 'isPerspectiveCamera', true )
+      if (cameras.length > 0) {
+        // Get the canvas element from the gl
+        var canvas = gl.domElement;
+        // Calculate the aspect ratio
+        var aspectRatio = canvas.clientWidth / canvas.clientHeight;
+        // Set aspectRatio to cameras
+        cameras.forEach(function(camera) {
+            const cameraPers = camera as PerspectiveCamera
+            cameraPers.aspect = aspectRatio;
+            cameraPers.updateProjectionMatrix();
+        });
+        // Update cameras list.
+        curState.setCamerasList(cameras.map(obj => obj as PerspectiveCamera))
+        // Set current camera and current index as 0
+        setCurrentCamera(cameras.length > 0 ? cameras[0] as PerspectiveCamera : new PerspectiveCamera())
+        curState.setCurrentCameraIndex(0)
+        set({ camera: cameras[0] as PerspectiveCamera});
+      }
+    }, [curState, scene]);
+
+    // This useEffect sets the current selected camera.
+    useEffect(() => {
+      if (curState.cameras.length > 0 && currentCamera) {
+        setCurrentCamera(curState.cameras[curState.currentCameraIndex] as PerspectiveCamera)
+        set({ camera: currentCamera as PerspectiveCamera});
+      }
+    }, [currentCamera, set, curState.currentCameraIndex, curState.cameras]);
 
     if (supportControls) {
       scene.traverse((o) => {
@@ -153,7 +192,6 @@ const OpenSimScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, supportCo
                   mixers[curState.currentAnimationIndex].clipAction(animations[curState.currentAnimationIndex]).time = currentTime;
                   setStartTime(curState.currentFrame)
                   mixers[curState.currentAnimationIndex].update(delta * curState.animationSpeed)
-
                 }
               }
             }
@@ -196,4 +234,4 @@ const OpenSimScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, supportCo
       </>
 }
 
-export default OpenSimScene
+export default observer(OpenSimScene)

--- a/src/components/pages/OpenSimScene.tsx
+++ b/src/components/pages/OpenSimScene.tsx
@@ -7,7 +7,6 @@ import { observer } from 'mobx-react'
 
 import SceneTreeModel from '../../helpers/SceneTreeModel'
 import { useModelContext } from '../../state/ModelUIStateContext'
-import { Camera } from 'three/src/cameras/Camera'
 import { PerspectiveCamera } from 'three/src/cameras/PerspectiveCamera'
 
 interface OpenSimSceneProps {
@@ -19,7 +18,7 @@ const OpenSimScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, supportCo
 
     // useGLTF suspends the component, it literally stops processing
     const { scene, animations } = useGLTF(currentModelPath);
-    const { set, camera, gl } = useThree();
+    const { set, gl } = useThree();
     const no_face_cull = (scene: Group)=>{
       if (scene) {
         scene.traverse((o)=>{
@@ -95,7 +94,7 @@ const OpenSimScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, supportCo
         curState.setCurrentCameraIndex(0)
         set({ camera: cameras[0] as PerspectiveCamera});
       }
-    }, [curState, scene]);
+    }, [curState, scene, gl.domElement, set]);
 
     // This useEffect sets the current selected camera.
     useEffect(() => {

--- a/src/state/ModelUIState.tsx
+++ b/src/state/ModelUIState.tsx
@@ -1,6 +1,7 @@
 import { makeObservable, observable, action } from 'mobx'
 import SceneTreeModel from '../helpers/SceneTreeModel'
 import { AnimationClip } from 'three/src/animation/AnimationClip'
+import { PerspectiveCamera } from 'three/src/cameras/PerspectiveCamera'
 import { Group } from 'three'
 
 export class ModelInfo {
@@ -26,6 +27,8 @@ export class ModelUIState {
     animationSpeed: number
     animations: AnimationClip[]
     currentAnimationIndex: number
+    cameras: PerspectiveCamera[]
+    currentCameraIndex: number
     selected: string
     deSelected: string
     cameraLayersMask: number
@@ -47,6 +50,8 @@ export class ModelUIState {
         this.animationSpeed = 1.0
         this.animations = []
         this.currentAnimationIndex = -1
+        this.cameras = []
+        this.currentCameraIndex = -1
         this.selected = ""
         this.deSelected = ""
         this.cameraLayersMask = -1
@@ -64,13 +69,17 @@ export class ModelUIState {
             setAnimationList: observable,
             setAnimationSpeed: action,
             animations: observable,
+            cameras: observable,
+            setCamerasList: action,
             selected: observable,
             setSelected: action,
             sceneTree: observable,
             setSceneTree: action,
             cameraLayersMask: observable,
             currentFrame: observable,
-            setCurrentFrame: action
+            setCurrentFrame: action,
+            currentCameraIndex: observable,
+            setCurrentCameraIndex: action
         })
         console.log("Created ModelUIState instance ", currentModelPathState)
     }
@@ -83,8 +92,10 @@ export class ModelUIState {
             this.cameraLayersMask = -1
             this.animating = false
             this.animationSpeed = 1
-			this.animations = []
+			      this.animations = []
             this.currentAnimationIndex = -1
+			      this.cameras = []
+            this.currentCameraIndex = -1
         }
     }
     setRotating(newState: boolean) {
@@ -105,6 +116,9 @@ export class ModelUIState {
     setCurrentAnimationIndex(newIndex: number) {
         this.currentAnimationIndex = newIndex
     }
+    setCurrentCameraIndex(newIndex: number) {
+        this.currentCameraIndex = newIndex
+    }
     setShowGlobalFrame(newState: boolean) {
         this.showGlobalFrame = newState 
     }
@@ -113,6 +127,9 @@ export class ModelUIState {
     }
     setAnimationList(animations: AnimationClip[]) {
         this.animations=animations
+    }
+    setCamerasList(cameras: PerspectiveCamera[]) {
+        this.cameras=cameras
     }
     setAnimationSpeed(newSpeed: number) {
         this.animationSpeed = newSpeed

--- a/src/state/ViewerState.tsx
+++ b/src/state/ViewerState.tsx
@@ -58,6 +58,7 @@ class ViewerState {
             setSnapshotFormat: action,
             setRecordedVideoName: action,
             setRecordedVideoFormat: action,
+            setIsLoggedIn: action,
             snapshotName: observable,
             snapshotFormat: observable,
             recordedVideoName: observable,


### PR DESCRIPTION
Now you can select a camera if multiple cameras are available for a gltf file.

Other things approached in this PR:
- Animation and camera selectors are only visible if animations or cameras are available.
- Fixed some mobx bugs (actions that were not declared actions and openSimScene not being an observer and updating wrongly).
- Fixed canvas height.