### PR TITLE
While processing frame, skip new frames being sent to avoid laggy sli…

### DIFF
--- a/src/state/ModelUIState.tsx
+++ b/src/state/ModelUIState.tsx
@@ -74,6 +74,7 @@ export class ModelUIState {
     debug: boolean
     simulationTime: number
     isGUIAnimating: boolean = false
+    processingSocketMessage: boolean = false
     constructor(
         currentModelPathState: string
     ) {
@@ -347,6 +348,9 @@ export class ModelUIState {
                 this.scene?.updateMatrixWorld(true);
                 break;
             case "Frame":
+                if (this.processingSocketMessage)
+                    return;
+                this.processingSocketMessage = true;
                 this.setSelected("", false)
                 var transforms = parsedMessage.Transforms;
                 for (var i = 0; i < transforms.length; i ++ ) {
@@ -364,8 +368,9 @@ export class ModelUIState {
                         this.updatePath(JSON.stringify(paths[p]));
                     }
                 }
-                this.scene?.updateMatrixWorld(true);
+                //this.scene?.updateMatrixWorld(true);
                 this.simulationTime = parsedMessage.time;
+                this.processingSocketMessage = false;
                 break;
             case "getOffsets":
                 this.sendText(this.getModelOffsetsJson());


### PR DESCRIPTION
…der/animation behavior or playing frames post process completion. This has been the behavior in 4.5 and before. May make sense to not skip frames if recording since responsiveness is less of a priority.