### PR TITLE
Allow integrate both dev and dev-gui. Fixed issue with url params not being picked when rendering. Fixed perf in old browsers.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,38 +50,33 @@ function App({ signOut, user }: WithAuthenticatorProps) {
     }
   };
 
-  React.useEffect(() => {
-    if (isSmallScreen && isPortrait && !curState.isGuiMode) {
-      // Force landscape mode
-      alert(t('app.switch_landscape'));
-    }
-  }, [isSmallScreen, isPortrait, t]);
 
-  React.useEffect(() => {
-    // Parse URL parameters
-    const urlParams = new URLSearchParams(window.location.search);
+      // Parse URL parameters
+      const urlParams = new URLSearchParams(window.location.search);
 
-    // Parameter to set gui mode
-    const cssParamGui = urlParams.get('css');
-    // Parameter to set if the browser being used is modern or not.
-    const cssParamModern = urlParams.get('modern')
+      // Parameter to set gui mode
+      const cssParamGui = urlParams.get('css');
+      // Parameter to set if the browser being used is modern or not.
+      const cssParamModern = urlParams.get('modern')
 
-    // Set gui mode if parameter is present unless we already know in gui mode.
-    if (!curState.isGuiMode) {
+      // Set gui mode if parameter is present unless we already know in gui mode.
       if (cssParamGui === 'gui') {
         curState.setIsGuiMode(true);
       } else {
         curState.setIsGuiMode(false);
       }
-    }
-    if (curState.isModernBrowser) {
       if (cssParamModern === 'false') {
         curState.setIsModernBrowser(false);
       } else {
         curState.setIsModernBrowser(true);
       }
-    }
-  }, [curState, viewerState]);
+
+    React.useEffect(() => {
+      if (isSmallScreen && isPortrait && !curState.isGuiMode) {
+        // Force landscape mode
+        alert(t('app.switch_landscape'));
+      }
+    }, [isSmallScreen, isPortrait, t]);
 
     // On file system we'll have a folder per model containing cached/versioned gltf, possibly .osim file, data files, display 
     // preferences

--- a/src/components/pages/ModelViewPage.tsx
+++ b/src/components/pages/ModelViewPage.tsx
@@ -275,6 +275,14 @@ useEffect(() => {
     uiState.viewerState.setIsLocalUpload(false);
   }
 
+  const [Perf, setPerf] = useState<any>(null);
+
+  useEffect(() => {
+    if (curState.isModernBrowser) {
+      import('r3f-perf').then(mod => setPerf(() => mod.Perf));
+    }
+  }, [curState.isModernBrowser]);
+
   function toggleOpenMenu(name: string = "") {
     // If same name, or empty just toggle.
     if (name === selectedTabName || name === "") setMenuOpen(!menuOpen);
@@ -369,7 +377,7 @@ useEffect(() => {
                 {showDebug && (
                   <>
                     <Stats />
-                    { /* curState.isModernBrowser && (<Perf position="top-right" />) */}
+                    { curState.isModernBrowser && Perf &&  (<Perf position="top-right" />) }
                   </>
                 )}
               </Canvas>

--- a/src/state/ModelUIState.tsx
+++ b/src/state/ModelUIState.tsx
@@ -81,7 +81,7 @@ export class ModelUIState {
         currentModelPathState: string
     ) {
         this.scene = null
-        this.isGuiMode = true
+        this.isGuiMode = false
         this.isModernBrowser = true
         this.zooming = false
         this.zoom_inOut = 0.0


### PR DESCRIPTION
Perf is not shown in old browsers, but it is not imported now, which was causing it to fail in previous version.

This works as long as the changes in GUI (https://github.com/opensim-org/opensim-gui/pull/1560) and opensim-visualizer (I do not have permissions to make changes to thar repository, so I forked it and tried to create a PR from the fork, but it is not allowed. These are the changes: https://github.com/AlbertoCasasOrtiz/opensim-visualizer/pull/1/files) are being used.

With the changes here and in those two repositories, I was able to use the same branch for both the online viewer and the GUI.