### PR TITLE
Recording of videos in offscreen canvas to control resolution

### DIFF
--- a/src/components/Components/FloatingControlsPanel.tsx
+++ b/src/components/Components/FloatingControlsPanel.tsx
@@ -12,6 +12,7 @@ import AddAPhotoTwoToneIcon from '@mui/icons-material/AddAPhotoTwoTone';
 import VideoCameraFrontTwoToneIcon from '@mui/icons-material/VideoCameraFrontTwoTone';
 import { useModelContext } from '../../state/ModelUIStateContext';
 import SnapShotModal from './SnapShotModal';
+import RecordingModal from './RecordingModal';
 import { ToggleButton } from '@mui/material';
 import { ModelInfo } from '../../state/ModelUIState';
 import { observer } from "mobx-react";
@@ -73,25 +74,7 @@ function FloatingControlsPanel(props :FloatingControlsPanelProps) {
         </Grid>
 
         <Grid item xs={6}>
-          <Tooltip title={t('bottomBar.record')} placement="right">
-            <IconButton
-            color={
-              viewerState.isProcessingVideo
-                ? "warning"
-                : viewerState.isRecordingVideo
-                  ? "error"
-                  : "primary"
-            }
-              disabled={viewerState.isProcessingVideo}
-              onClick={() => {
-                if (!viewerState.isRecordingVideo) {
-                  props.videoRecorderRef.current.startRecording();
-                } else {
-                  props.videoRecorderRef.current.stopRecording();}}
-              }>
-                <VideoCameraFrontTwoToneIcon />
-            </IconButton>
-          </Tooltip>
+          <RecordingModal videoRecorderRef={props.videoRecorderRef} />
         </Grid>
 
         <Grid item xs={6}>

--- a/src/components/Components/OpenSimGUIScene.tsx
+++ b/src/components/Components/OpenSimGUIScene.tsx
@@ -202,7 +202,7 @@ const OpenSimGUIScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, suppor
     )
 
 
-     useFrame((state, delta) => {
+    useFrame((state, delta) => {
       if (!useEffectRunning) {
         // Selection bounding box
         if (curState.selected === "") {
@@ -245,7 +245,14 @@ const OpenSimGUIScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, suppor
           }
 
           // Start new animation
-          mixers[viewerState.currentAnimationIndex]?.clipAction(viewerState.animations[viewerState.currentAnimationIndex]).play();
+          const action = mixers[viewerState.currentAnimationIndex]?.clipAction(viewerState.animations[viewerState.currentAnimationIndex]);
+          action?.play();
+
+          // Update animation time immediately when animation changes
+          if (action) {
+            const currentTime = action.time;
+            viewerState.setCurrentAnimationTime(currentTime);
+          }
         }
 
         // Handle animation playback with the three cases
@@ -267,8 +274,10 @@ const OpenSimGUIScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, suppor
             mixer.update(delta * viewerState.animationSpeed);
             applyAnimationColors();
 
-            // Update slider value for React re-renders
+            // Update animation time and slider value for React re-renders
             const currentTime = action.time;
+            viewerState.setCurrentAnimationTime(currentTime); // Always update animation time
+
             const newFrame = Math.trunc((currentTime / duration) * 100);
             if (newFrame !== curState.currentFrame) {
               curState.setCurrentFrame(newFrame);
@@ -281,9 +290,15 @@ const OpenSimGUIScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, suppor
               const framePercentage = curState.currentFrame / 100;
               const scrubTime = duration * framePercentage;
               action.time = scrubTime;
-              mixer.update(delta * viewerState.animationSpeed); // Small update to apply changes
+              mixer.update(0); // Zero delta to apply time change without advancing
               applyAnimationColors();
+
+              // Update animation time
+              viewerState.setCurrentAnimationTime(scrubTime);
               setStartTime(curState.currentFrame);
+            } else {
+              // Even when paused, ensure animation time is current
+              viewerState.setCurrentAnimationTime(action.time);
             }
 
           // CASE 3: RECORDING deterministic frame stepping
@@ -292,10 +307,21 @@ const OpenSimGUIScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, suppor
               const framePercentage = curState.currentFrame / 100;
               const recTime = duration * framePercentage;
               action.time = recTime;
-              mixer.update(delta * viewerState.animationSpeed); // Small update to apply changes
+              mixer.update(0); // Zero delta to apply time change without advancing
               applyAnimationColors();
+
+              // Update animation time
+              viewerState.setCurrentAnimationTime(recTime);
               setStartTime(curState.currentFrame);
+            } else {
+              // Ensure animation time is current during recording
+              viewerState.setCurrentAnimationTime(action.time);
             }
+          }
+        } else {
+          // No active animation, reset animation time
+          if (viewerState.currentAnimationTime !== 0) {
+            viewerState.setCurrentAnimationTime(0);
           }
         }
       }

--- a/src/components/Components/OpenSimGUIScene.tsx
+++ b/src/components/Components/OpenSimGUIScene.tsx
@@ -201,108 +201,117 @@ const OpenSimGUIScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, suppor
         }
     )
 
- 
-    useFrame((state, delta) => {
-    //console.log(camera.position)
-    //console.log(camera.quaternion)
-      if (!useEffectRunning) {
-            if (curState.selected === "") {
-              bboxRef.current!.visible = false
-            }
-            else {
-              let selectedObject = sceneObjectMap.get(curState.selected)!
-              if (selectedObject !== undefined && selectedObject.type !== 'BoxHelper') {
-                  if (bboxRef.current !== null) {
-                    bboxRef.current.setFromObject(selectedObject);
-                    bboxRef.current!.visible = true
-                }
-              }
-            }
-            csRef.current!.visible =  curState.showGlobalFrame
-            const viewerState = curState.viewerState
-            if (viewerState.currentAnimationIndex !== animationIndex) {
-              const newAnimationIndex = viewerState.currentAnimationIndex
-              const oldIndex  = animationIndex
-              // animation has changed
-              if (oldIndex !== -1 && mixers[oldIndex]!==undefined) {
-                mixers[oldIndex].stopAllAction()
-              }
-              setAnimationIndex(newAnimationIndex)
-              if (mixers.length -1 < newAnimationIndex) {
-                // create a mixer for the animation
-                const nextMixer = new AnimationMixer(camera)
-                // targetMixerRef.current = new AnimationMixer(targetRef.current!);
-                const nextAnimation = viewerState.animations[viewerState.currentAnimationIndex];
-                nextAnimation.tracks[0].setInterpolation(THREE.InterpolateLinear);
-                nextAnimation.tracks[1].setInterpolation(THREE.InterpolateLinear);
-                nextMixer.clipAction(nextAnimation, nextAnimation.name.startsWith("cam")?camera:scene);
-                mixers.push(nextMixer);
-                //const targetClip = new THREE.AnimationClip('targetMove', nextAnimation.duration, [nextAnimation.tracks[2]]);
-                //targetMixerRef.current.clipAction(targetClip, targetRef.current!).play();
-                
-                //(controls as unknown as CameraControls).enabled = true;
-                // (controls as unknown as CameraControls).setLookAt(nextAnimation.tracks[0].values[0],
-                //       nextAnimation.tracks[0].values[1], 
-                //       nextAnimation.tracks[0].values[2], 
-                //       nextAnimation.tracks[2].values[0],
-                //       nextAnimation.tracks[2].values[1], 
-                //       nextAnimation.tracks[2].values[2], true);
-              }
-              // Leave to animate button to start playing
-              mixers[viewerState.currentAnimationIndex]?.clipAction(viewerState.animations[viewerState.currentAnimationIndex]).play()
-            }
-            if (viewerState.animating || curState.isGUIAnimating){
-              if (viewerState.currentAnimationIndex!==-1) {
-                let duration = mixers[viewerState.currentAnimationIndex].clipAction(viewerState.animations[viewerState.currentAnimationIndex]).getClip().duration;
-                if(curState.currentFrame !== startTime && viewerState.animating) {
-                  const framePercentage = curState.currentFrame / 100;
-                  const currentTimeInSlider = duration * framePercentage;
-                  mixers[viewerState.currentAnimationIndex].clipAction(viewerState.animations[viewerState.currentAnimationIndex]).time =  currentTimeInSlider;
-                }
-                const currentTime = mixers[viewerState.currentAnimationIndex].clipAction(viewerState.animations[viewerState.currentAnimationIndex]).time
-                //mixers[viewerState.currentAnimationIndex].setTime(viewerState.animating?animationTime:curState.simulationTime)
-                mixers[viewerState.currentAnimationIndex].update(delta * viewerState.animationSpeed);
-                //targetMixerRef.current!.update(delta * curState.animationSpeed);
-                //camera.lookAt(targetRef.current!.position)
 
-                // For material at index "key" setColor to nodes["value"].translation
-                applyAnimationColors();
-                curState.setCurrentFrame(Math.trunc((currentTime / duration) * 100));
-                setStartTime(Math.trunc((currentTime / duration) * 100));
-                // Disable looping for now
-                // if (curState.currentFrame < prevFrame && curState.viewerState.animating){
-                //   curState.viewerState.setAnimating(false);
-                //   curState.setCurrentFrame(0);
-                // }
-                //console.log(currentTime, duration, startTime, curState.currentFrame);
-              }
-            } else {
-              if (viewerState.currentAnimationIndex!==-1) {
-                if(curState.currentFrame !== startTime) {
-                  let duration = mixers[viewerState.currentAnimationIndex]?.clipAction(viewerState.animations[viewerState.currentAnimationIndex]).getClip().duration;
-                  const framePercentage = curState.currentFrame / 100;
-                  const currentTime = duration * framePercentage;
-                  // For material at index "key" setColor to nodes["value"].translation
-                  applyAnimationColors();
-                  mixers[viewerState.currentAnimationIndex].clipAction(viewerState.animations[viewerState.currentAnimationIndex]).time = currentTime;
-                  setStartTime(curState.currentFrame)
-                  mixers[viewerState.currentAnimationIndex].update(delta * viewerState.animationSpeed)
-                  //targetMixerRef.current!.update(delta * curState.animationSpeed);
-                  //camera.lookAt(targetRef.current!.position)
-                }
-              }
+     useFrame((state, delta) => {
+      if (!useEffectRunning) {
+        // Selection bounding box
+        if (curState.selected === "") {
+          bboxRef.current!.visible = false;
+        } else {
+          let selectedObject = sceneObjectMap.get(curState.selected)!;
+          if (selectedObject !== undefined && selectedObject.type !== 'BoxHelper') {
+            if (bboxRef.current !== null) {
+              bboxRef.current.setFromObject(selectedObject);
+              bboxRef.current!.visible = true;
             }
-          
+          }
+        }
+
+        // Coordinate system visibility
+        csRef.current!.visible = curState.showGlobalFrame;
+
+        const viewerState = curState.viewerState;
+
+        // Handle animation index change
+        if (viewerState.currentAnimationIndex !== animationIndex) {
+          const newAnimationIndex = viewerState.currentAnimationIndex;
+          const oldIndex = animationIndex;
+
+          // Stop old animation
+          if (oldIndex !== -1 && mixers[oldIndex] !== undefined) {
+            mixers[oldIndex].stopAllAction();
+          }
+
+          setAnimationIndex(newAnimationIndex);
+
+          // Create mixer if needed (GUI-specific camera animation setup)
+          if (mixers.length - 1 < newAnimationIndex) {
+            const nextMixer = new AnimationMixer(camera);
+            const nextAnimation = viewerState.animations[viewerState.currentAnimationIndex];
+            nextAnimation.tracks[0].setInterpolation(THREE.InterpolateLinear);
+            nextAnimation.tracks[1].setInterpolation(THREE.InterpolateLinear);
+            nextMixer.clipAction(nextAnimation, nextAnimation.name.startsWith("cam") ? camera : scene);
+            mixers.push(nextMixer);
+          }
+
+          // Start new animation
+          mixers[viewerState.currentAnimationIndex]?.clipAction(viewerState.animations[viewerState.currentAnimationIndex]).play();
+        }
+
+        // Handle animation playback with the three cases
+        const idx = viewerState.currentAnimationIndex;
+        if (idx !== -1) {
+          const mixer = mixers[idx];
+          const action = mixer.clipAction(viewerState.animations[idx]);
+          const duration = action.getClip().duration;
+
+          // CASE 1: PLAYING (animating OR GUI animating)
+          if (viewerState.animating || curState.isGUIAnimating) {
+            // Handle slider-driven time when animating
+            if (curState.currentFrame !== startTime && viewerState.animating) {
+              const framePercentage = curState.currentFrame / 100;
+              const currentTimeInSlider = duration * framePercentage;
+              action.time = currentTimeInSlider;
+            }
+
+            mixer.update(delta * viewerState.animationSpeed);
+            applyAnimationColors();
+
+            // Update slider value for React re-renders
+            const currentTime = action.time;
+            const newFrame = Math.trunc((currentTime / duration) * 100);
+            if (newFrame !== curState.currentFrame) {
+              curState.setCurrentFrame(newFrame);
+              setStartTime(newFrame);
+            }
+
+          // CASE 2: PAUSED but user moves slider
+          } else if (!viewerState.isRecordingVideo) {
+            if (curState.currentFrame !== startTime) {
+              const framePercentage = curState.currentFrame / 100;
+              const scrubTime = duration * framePercentage;
+              action.time = scrubTime;
+              mixer.update(delta * viewerState.animationSpeed); // Small update to apply changes
+              applyAnimationColors();
+              setStartTime(curState.currentFrame);
+            }
+
+          // CASE 3: RECORDING deterministic frame stepping
+          } else {
+            if (curState.currentFrame !== startTime) {
+              const framePercentage = curState.currentFrame / 100;
+              const recTime = duration * framePercentage;
+              action.time = recTime;
+              mixer.update(delta * viewerState.animationSpeed); // Small update to apply changes
+              applyAnimationColors();
+              setStartTime(curState.currentFrame);
+            }
+          }
+        }
       }
+
+      // FPS counter
       frameCount++;
-      renderTime+=delta;
-      if (frameCount === 60){
-        const fps = Math.round(frameCount/renderTime);
+      renderTime += delta;
+      if (frameCount === 60) {
+        const fps = Math.round(frameCount / renderTime);
         curState.setFPS(fps);
         frameCount = 0;
         renderTime = 0;
-      } 
-    })
+      }
+    });
+
+
     // Next block would show bubble on selection with name
     // useFrame((state, delta) => {
     //   if (curState.selectedObject!==null){

--- a/src/components/Components/OpenSimScene.tsx
+++ b/src/components/Components/OpenSimScene.tsx
@@ -189,72 +189,74 @@ const OpenSimScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, supportCo
 
     useFrame((state, delta) => {
       if (!useEffectRunning) {
-          if (curState !== undefined) {
-            if (supportControls ) {
-              if (curState.selected === "") {
-                if (objectSelectionBox !== null)
-                    objectSelectionBox!.visible = false
-              }
-              else {
-                let selectedObject = sceneObjectMap.get(curState.selected)!
-                if (selectedObject !== undefined && selectedObject.type === "Mesh") {
-                    if (objectSelectionBox !== null) {
-                      objectSelectionBox?.setFromObject(selectedObject);
-                      objectSelectionBox!.visible = true
-                  }
-                }
-              }
-            }
-
-            if (curState.viewerState.currentAnimationIndex !== animationIndex) {
-              const newAnimationIndex = curState.viewerState.currentAnimationIndex
-              const oldIndex  = animationIndex
-              // animation has changed
-              if (oldIndex !== -1){
-                mixers[oldIndex].stopAllAction()
-              }
-              setAnimationIndex(newAnimationIndex)
-              mixers[curState.viewerState.currentAnimationIndex]?.clipAction(animations[curState.viewerState.currentAnimationIndex]).play()
-            }
-            if (supportControls && curState.viewerState.animating){
-              if (curState.viewerState.currentAnimationIndex!==-1) {
-                let duration = mixers[curState.viewerState.currentAnimationIndex].clipAction(animations[curState.viewerState.currentAnimationIndex]).getClip().duration;
-
-                if(curState.currentFrame !== startTime) {
-                  const framePercentage = curState.currentFrame / 100;
-                  const currentTimeInSlider = duration * framePercentage;
-                  mixers[curState.viewerState.currentAnimationIndex].clipAction(animations[curState.viewerState.currentAnimationIndex]).time =  currentTimeInSlider;
-                }
-                const currentTime = mixers[curState.viewerState.currentAnimationIndex].clipAction(animations[curState.viewerState.currentAnimationIndex]).time
-                mixers[curState.viewerState.currentAnimationIndex].update(delta * curState.viewerState.animationSpeed)
-                //console.log(duration)
-                // For material at index "key" setColor to nodes["value"].translation
-                applyAnimationColors();
-                curState.setCurrentFrame(Math.trunc((currentTime / duration) * 100))
-                setStartTime(Math.trunc((currentTime / duration) * 100))
-              }
-            } else if (supportControls) {
-              if (curState.viewerState.currentAnimationIndex!==-1) {
-                if(curState.currentFrame !== startTime) {
-                  let duration = mixers[curState.viewerState.currentAnimationIndex]?.clipAction(animations[curState.viewerState.currentAnimationIndex]).getClip().duration;
-                  const framePercentage = curState.currentFrame / 100;
-                  const currentTime = duration * framePercentage;
-                  // For material at index "key" setColor to nodes["value"].translation
-                  applyAnimationColors();
-                  mixers[curState.viewerState.currentAnimationIndex].clipAction(animations[curState.viewerState.currentAnimationIndex]).time = currentTime;
-                  setStartTime(curState.currentFrame)
-                  mixers[curState.viewerState.currentAnimationIndex].update(delta * curState.viewerState.animationSpeed)
+        if (curState !== undefined) {
+          if (supportControls) {
+            if (curState.selected === "") {
+              if (objectSelectionBox !== null)
+                objectSelectionBox!.visible = false;
+            } else {
+              let selectedObject = sceneObjectMap.get(curState.selected)!;
+              if (selectedObject !== undefined && selectedObject.type === "Mesh") {
+                if (objectSelectionBox !== null) {
+                  objectSelectionBox?.setFromObject(selectedObject);
+                  objectSelectionBox!.visible = true;
                 }
               }
             }
           }
+
+          if (curState.viewerState.currentAnimationIndex !== animationIndex) {
+            const newAnimationIndex = curState.viewerState.currentAnimationIndex;
+            const oldIndex = animationIndex;
+            if (oldIndex !== -1) mixers[oldIndex].stopAllAction();
+            setAnimationIndex(newAnimationIndex);
+            mixers[newAnimationIndex]?.clipAction(animations[newAnimationIndex]).play();
+          }
+
+          const idx = curState.viewerState.currentAnimationIndex;
+          if (supportControls && idx !== -1) {
+            const mixer = mixers[idx];
+            const action = mixer.clipAction(animations[idx]);
+            const duration = action.getClip().duration;
+
+            // CASE 1: PLAYING (animating)
+            if (curState.viewerState.animating) {
+              mixer.update(delta * curState.viewerState.animationSpeed);
+              applyAnimationColors();
+
+              // Always update slider value so React re-renders
+              const newFrame = Math.trunc((action.time / duration) * 100);
+              if (newFrame !== curState.currentFrame) {
+                curState.setCurrentFrame(newFrame);
+                setStartTime(newFrame);
+              }
+
+            // CASE 2: PAUSED but user moves slider
+            } else if (!curState.viewerState.isRecordingVideo) {
+              if (curState.currentFrame !== startTime) {
+                const framePercentage = curState.currentFrame / 100;
+                const scrubTime = duration * framePercentage;
+                mixer.setTime(scrubTime);
+                applyAnimationColors();
+                setStartTime(curState.currentFrame);
+              }
+
+            // CASE 3: RECORDING deterministic frame stepping
+            } else {
+              if (curState.currentFrame !== startTime) {
+                const framePercentage = curState.currentFrame / 100;
+                const recTime = duration * framePercentage;
+                mixer.setTime(recTime);
+                applyAnimationColors();
+                setStartTime(curState.currentFrame);
+              }
+            }
+          }
+        }
       }
-      if (lightRef.current) {
-        setDirectionalVisible(lightRef.current.visible);
-      }
-      if (spotlightRef.current) {
-        setSpotVisible(spotlightRef.current.visible);
-      }
+
+      if (lightRef.current) setDirectionalVisible(lightRef.current.visible);
+      if (spotlightRef.current) setSpotVisible(spotlightRef.current.visible);
       if (dirLightHelperRef.current && lightRef.current) {
         dirLightHelperRef.current.visible = lightRef.current.visible;
         dirLightHelperRef.current.update();
@@ -263,7 +265,8 @@ const OpenSimScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, supportCo
         spotLightHelperRef.current.visible = spotlightRef.current.visible;
         spotLightHelperRef.current.update();
       }
-    })
+    });
+
 
     useEffect(() => {
         //console.log("OpenSimScene.useEffect called ", curState.currentModelPath)

--- a/src/components/Components/OpenSimScene.tsx
+++ b/src/components/Components/OpenSimScene.tsx
@@ -208,47 +208,57 @@ const OpenSimScene: React.FC<OpenSimSceneProps> = ({ currentModelPath, supportCo
           if (curState.viewerState.currentAnimationIndex !== animationIndex) {
             const newAnimationIndex = curState.viewerState.currentAnimationIndex;
             const oldIndex = animationIndex;
-            if (oldIndex !== -1) mixers[oldIndex].stopAllAction();
+            if (oldIndex !== -1 && mixers[oldIndex]) mixers[oldIndex].stopAllAction();
             setAnimationIndex(newAnimationIndex);
-            mixers[newAnimationIndex]?.clipAction(animations[newAnimationIndex]).play();
+
+            if (newAnimationIndex !== -1 && mixers[newAnimationIndex]) {
+              mixers[newAnimationIndex].clipAction(animations[newAnimationIndex]).play();
+            }
           }
 
           const idx = curState.viewerState.currentAnimationIndex;
-          if (supportControls && idx !== -1) {
+          if (supportControls && idx !== -1 && mixers[idx]) {
             const mixer = mixers[idx];
             const action = mixer.clipAction(animations[idx]);
             const duration = action.getClip().duration;
 
-            // CASE 1: PLAYING (animating)
+            // CASE 1: PLAYING (animating) - Update animation time and UI
             if (curState.viewerState.animating) {
               mixer.update(delta * curState.viewerState.animationSpeed);
               applyAnimationColors();
 
-              // Always update slider value so React re-renders
-              const newFrame = Math.trunc((action.time / duration) * 100);
+              // Update the currentAnimationTime in state
+              const currentTime = action.time;
+              curState.viewerState.setCurrentAnimationTime(currentTime);
+
+              // Also update the percentage for backward compatibility if needed
+              const newFrame = Math.trunc((currentTime / duration) * 100);
               if (newFrame !== curState.currentFrame) {
                 curState.setCurrentFrame(newFrame);
-                setStartTime(newFrame);
               }
 
-            // CASE 2: PAUSED but user moves slider
+            // CASE 2: PAUSED but user changes time via slider/input
             } else if (!curState.viewerState.isRecordingVideo) {
-              if (curState.currentFrame !== startTime) {
-                const framePercentage = curState.currentFrame / 100;
-                const scrubTime = duration * framePercentage;
-                mixer.setTime(scrubTime);
+              // Check if animation time has been changed externally (via UI)
+              const currentTime = action.time;
+              const stateTime = curState.viewerState.currentAnimationTime;
+
+              // If times don't match, sync the animation to the UI time
+              if (Math.abs(currentTime - stateTime) > 0.001) {
+                action.time = stateTime;
+                mixer.update(0); // Update mixer without advancing time
                 applyAnimationColors();
-                setStartTime(curState.currentFrame);
               }
 
-            // CASE 3: RECORDING deterministic frame stepping
+            // CASE 3: RECORDING - Use deterministic time stepping
             } else {
-              if (curState.currentFrame !== startTime) {
-                const framePercentage = curState.currentFrame / 100;
-                const recTime = duration * framePercentage;
-                mixer.setTime(recTime);
+              // During recording, the VideoRecorder controls the time directly
+              // Just ensure the animation is synced to the current time
+              const currentTime = curState.viewerState.currentAnimationTime;
+              if (Math.abs(action.time - currentTime) > 0.001) {
+                action.time = currentTime;
+                mixer.update(0);
                 applyAnimationColors();
-                setStartTime(curState.currentFrame);
               }
             }
           }

--- a/src/components/Components/RecordingModal.tsx
+++ b/src/components/Components/RecordingModal.tsx
@@ -31,7 +31,6 @@ const qualityLevels = [
 
 const videoFormats = [
   { label: "MP4", value: "mp4" },
-  { label: "WEBM", value: "webm" },
   { label: "MOV", value: "mov" },
 ];
 

--- a/src/components/Components/RecordingModal.tsx
+++ b/src/components/Components/RecordingModal.tsx
@@ -22,9 +22,9 @@ interface RecordingModalProps {
 }
 
 const resolutions = [
-  { label: "144p", width: 256, height: 144 },
-  { label: "240p", width: 426, height: 240 },
-  { label: "360p", width: 640, height: 360 },
+//  { label: "144p", width: 256, height: 144 },
+//  { label: "240p", width: 426, height: 240 },
+//  { label: "360p", width: 640, height: 360 },
   { label: "480p", width: 854, height: 480 },
   { label: "720p_HD", width: 1280, height: 720 },
   { label: "1080p_HD", width: 1920, height: 1080 },
@@ -33,9 +33,26 @@ const resolutions = [
 ];
 
 const videoFormats = [
-  { label: "WEBM", value: "webm" },
+//  { label: "WEBM", value: "webm" },
   { label: "MP4", value: "mp4" },
   { label: "MOV", value: "mov" },
+];
+
+const fpsValues = [
+  24,
+  30,
+  60,
+//  120
+];
+
+const aspectRatios = [
+  { label: "4:3", value: "4:3", description: "standard" },
+  { label: "16:9", value: "16:9", description: "widescreen" },
+  { label: "21:9", value: "21:9", description: "ultrawide" },
+  { label: "6:13", value: "9:16", description: "smartphone" },
+  { label: "9:16", value: "9:16", description: "vertical" },
+  { label: "1:1", value: "1:1", description: "square" },
+  { label: "3:2", value: "3:2", description: "photo size" },
 ];
 
 const RecordingModal: React.FC<RecordingModalProps> = ({ videoRecorderRef }) => {
@@ -46,6 +63,8 @@ const RecordingModal: React.FC<RecordingModalProps> = ({ videoRecorderRef }) => 
   const [open, setOpen] = useState(false);
   const [selectedResolution, setSelectedResolution] = useState("720p_HD");
   const [selectedFormat, setSelectedFormat] = useState("webm");
+  const [selectedFPS, setSelectedFPS] = useState(30);
+  const [selectedAspectRatio, setSelectedAspectRatio] = useState("16:9");
 
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
@@ -62,6 +81,17 @@ const RecordingModal: React.FC<RecordingModalProps> = ({ videoRecorderRef }) => 
     setSelectedFormat(value);
     viewerState.recordedVideoFormat = value;
   };
+
+  const handleFPSChange = (value: number) => {
+    setSelectedFPS(Number(value))
+    viewerState.recordedVideoFPS = Number(value);
+  };
+
+  const handleAspectRatioChange = (value: string) => {
+    setSelectedAspectRatio(value)
+    viewerState.recordedVideoAspectRatio = value;
+  };
+
 
   const handleResolutionChange = (value: string) => {
     setSelectedResolution(value);
@@ -97,6 +127,7 @@ const RecordingModal: React.FC<RecordingModalProps> = ({ videoRecorderRef }) => 
         <DialogTitle>{t("bottomBar.record")}</DialogTitle>
 
         <DialogContent sx={{ minWidth: 300 }}>
+          {/* Video Format */}
           <FormControl fullWidth margin="dense">
             <InputLabel>Video Format</InputLabel>
             <Select
@@ -112,6 +143,7 @@ const RecordingModal: React.FC<RecordingModalProps> = ({ videoRecorderRef }) => 
             </Select>
           </FormControl>
 
+          {/* Resolution */}
           <FormControl fullWidth margin="dense" sx={{ marginTop: 2 }}>
             <InputLabel>Select Resolution</InputLabel>
             <Select
@@ -122,6 +154,38 @@ const RecordingModal: React.FC<RecordingModalProps> = ({ videoRecorderRef }) => 
               {resolutions.map((res) => (
                 <MenuItem key={res.label} value={res.label}>
                   {res.label} ({res.width}×{res.height})
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          {/* FPS */}
+          <FormControl fullWidth margin="dense" sx={{ marginTop: 2 }}>
+            <InputLabel>FPS</InputLabel>
+            <Select
+              value={selectedFPS}
+              label="FPS"
+              onChange={(e) => handleFPSChange(Number(e.target.value))}
+            >
+              {fpsValues.map((fps) => (
+                <MenuItem key={fps} value={fps}>
+                  {fps}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          {/* Aspect Ratio */}
+          <FormControl fullWidth margin="dense" sx={{ marginTop: 2 }}>
+            <InputLabel>Aspect Ratio</InputLabel>
+            <Select
+              value={selectedAspectRatio}
+              label="Aspect Ratio"
+              onChange={(e) => handleAspectRatioChange(e.target.value)}
+            >
+              {aspectRatios.map((ar) => (
+                <MenuItem key={ar.value} value={ar.value}>
+                  {ar.label} ({ar.description})
                 </MenuItem>
               ))}
             </Select>

--- a/src/components/Components/RecordingModal.tsx
+++ b/src/components/Components/RecordingModal.tsx
@@ -21,35 +21,26 @@ interface RecordingModalProps {
   videoRecorderRef: React.MutableRefObject<any>;
 }
 
-const resolutions = [
-//  { label: "144p", width: 256, height: 144 },
-//  { label: "240p", width: 426, height: 240 },
-//  { label: "360p", width: 640, height: 360 },
-  { label: "480p", width: 854, height: 480 },
-  { label: "720p_HD", width: 1280, height: 720 },
-  { label: "1080p_HD", width: 1920, height: 1080 },
-  { label: "1440p_HD", width: 2560, height: 1440 },
-  { label: "2160p_4K", width: 3840, height: 2160 },
+// Define quality levels that will be used as base dimensions
+const qualityLevels = [
+  { label: "720p HD", baseDimension: 720 },
+  { label: "1080p HD", baseDimension: 1080 },
+  { label: "1440p HD", baseDimension: 1440 },
+  { label: "2160p 4K", baseDimension: 2160 },
 ];
 
 const videoFormats = [
-//  { label: "WEBM", value: "webm" },
   { label: "MP4", value: "mp4" },
+  { label: "WEBM", value: "webm" },
   { label: "MOV", value: "mov" },
 ];
 
-const fpsValues = [
-  24,
-  30,
-  60,
-//  120
-];
+const fpsValues = [24, 30, 60];
 
 const aspectRatios = [
   { label: "4:3", value: "4:3", description: "standard" },
   { label: "16:9", value: "16:9", description: "widescreen" },
   { label: "21:9", value: "21:9", description: "ultrawide" },
-  { label: "6:13", value: "9:16", description: "smartphone" },
   { label: "9:16", value: "9:16", description: "vertical" },
   { label: "1:1", value: "1:1", description: "square" },
   { label: "3:2", value: "3:2", description: "photo size" },
@@ -61,8 +52,8 @@ const RecordingModal: React.FC<RecordingModalProps> = ({ videoRecorderRef }) => 
   const viewerState = curState.viewerState;
 
   const [open, setOpen] = useState(false);
-  const [selectedResolution, setSelectedResolution] = useState("720p_HD");
-  const [selectedFormat, setSelectedFormat] = useState("webm");
+  const [selectedQuality, setSelectedQuality] = useState("720p HD");
+  const [selectedFormat, setSelectedFormat] = useState("mp4");
   const [selectedFPS, setSelectedFPS] = useState(30);
   const [selectedAspectRatio, setSelectedAspectRatio] = useState("16:9");
 
@@ -79,26 +70,25 @@ const RecordingModal: React.FC<RecordingModalProps> = ({ videoRecorderRef }) => 
 
   const handleFormatChange = (value: string) => {
     setSelectedFormat(value);
-    viewerState.recordedVideoFormat = value;
+    viewerState.setRecordedVideoFormat(value);
   };
 
   const handleFPSChange = (value: number) => {
-    setSelectedFPS(Number(value))
-    viewerState.recordedVideoFPS = Number(value);
+    setSelectedFPS(Number(value));
+    viewerState.setRecorderFPS(Number(value));
   };
 
   const handleAspectRatioChange = (value: string) => {
-    setSelectedAspectRatio(value)
-    viewerState.recordedVideoAspectRatio = value;
+    setSelectedAspectRatio(value);
+    viewerState.setRecorderAspectRatio(value);
   };
 
-
-  const handleResolutionChange = (value: string) => {
-    setSelectedResolution(value);
-    const chosen = resolutions.find((r) => r.label === value);
+  const handleQualityChange = (value: string) => {
+    setSelectedQuality(value);
+    const chosen = qualityLevels.find((q) => q.label === value);
     if (chosen) {
-      viewerState.videoRecorderWidth = chosen.width;
-      viewerState.videoRecorderHeight = chosen.height;
+      // Only set the base dimension, let the aspect ratio calculation determine final dimensions
+      viewerState.setVideoRecorderBaseDimension(chosen.baseDimension);
     }
   };
 
@@ -143,33 +133,17 @@ const RecordingModal: React.FC<RecordingModalProps> = ({ videoRecorderRef }) => 
             </Select>
           </FormControl>
 
-          {/* Resolution */}
+          {/* Quality Level */}
           <FormControl fullWidth margin="dense" sx={{ marginTop: 2 }}>
-            <InputLabel>Select Resolution</InputLabel>
+            <InputLabel>Quality Level</InputLabel>
             <Select
-              value={selectedResolution}
-              label="Select Resolution"
-              onChange={(e) => handleResolutionChange(e.target.value)}
+              value={selectedQuality}
+              label="Quality Level"
+              onChange={(e) => handleQualityChange(e.target.value)}
             >
-              {resolutions.map((res) => (
-                <MenuItem key={res.label} value={res.label}>
-                  {res.label} ({res.width}×{res.height})
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-
-          {/* FPS */}
-          <FormControl fullWidth margin="dense" sx={{ marginTop: 2 }}>
-            <InputLabel>FPS</InputLabel>
-            <Select
-              value={selectedFPS}
-              label="FPS"
-              onChange={(e) => handleFPSChange(Number(e.target.value))}
-            >
-              {fpsValues.map((fps) => (
-                <MenuItem key={fps} value={fps}>
-                  {fps}
+              {qualityLevels.map((quality) => (
+                <MenuItem key={quality.label} value={quality.label}>
+                  {quality.label}
                 </MenuItem>
               ))}
             </Select>
@@ -190,7 +164,25 @@ const RecordingModal: React.FC<RecordingModalProps> = ({ videoRecorderRef }) => 
               ))}
             </Select>
           </FormControl>
+
+
+          {/* FPS */}
+          <FormControl fullWidth margin="dense" sx={{ marginTop: 2 }}>
+            <InputLabel>FPS</InputLabel>
+            <Select
+              value={selectedFPS}
+              label="FPS"
+              onChange={(e) => handleFPSChange(Number(e.target.value))}
+            >
+              {fpsValues.map((fps) => (
+                <MenuItem key={fps} value={fps}>
+                  {fps}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
         </DialogContent>
+
 
         <DialogActions>
           <Button onClick={handleRecord}>Record</Button>

--- a/src/components/Components/RecordingModal.tsx
+++ b/src/components/Components/RecordingModal.tsx
@@ -1,0 +1,140 @@
+import React, { useState } from "react";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  IconButton,
+  Tooltip,
+} from "@mui/material";
+import VideoCameraFrontTwoToneIcon from "@mui/icons-material/VideoCameraFrontTwoTone";
+import { useTranslation } from "react-i18next";
+import { useModelContext } from "../../state/ModelUIStateContext";
+import { observer } from "mobx-react";
+
+interface RecordingModalProps {
+  videoRecorderRef: React.MutableRefObject<any>;
+}
+
+const resolutions = [
+  { label: "144p", width: 256, height: 144 },
+  { label: "240p", width: 426, height: 240 },
+  { label: "360p", width: 640, height: 360 },
+  { label: "480p", width: 854, height: 480 },
+  { label: "720p_HD", width: 1280, height: 720 },
+  { label: "1080p_HD", width: 1920, height: 1080 },
+  { label: "1440p_HD", width: 2560, height: 1440 },
+  { label: "2160p_4K", width: 3840, height: 2160 },
+];
+
+const videoFormats = [
+  { label: "WEBM", value: "webm" },
+  { label: "MP4", value: "mp4" },
+  { label: "MOV", value: "mov" },
+];
+
+const RecordingModal: React.FC<RecordingModalProps> = ({ videoRecorderRef }) => {
+  const { t } = useTranslation();
+  const curState = useModelContext();
+  const viewerState = curState.viewerState;
+
+  const [open, setOpen] = useState(false);
+  const [selectedResolution, setSelectedResolution] = useState("720p_HD");
+  const [selectedFormat, setSelectedFormat] = useState("webm");
+
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  const handleRecord = () => {
+    setOpen(false);
+
+    if (videoRecorderRef?.current && !viewerState.isRecordingVideo) {
+      videoRecorderRef.current.startRecording();
+    }
+  };
+
+  const handleFormatChange = (value: string) => {
+    setSelectedFormat(value);
+    viewerState.recordedVideoFormat = value;
+  };
+
+  const handleResolutionChange = (value: string) => {
+    setSelectedResolution(value);
+    const chosen = resolutions.find((r) => r.label === value);
+    if (chosen) {
+      viewerState.videoRecorderWidth = chosen.width;
+      viewerState.videoRecorderHeight = chosen.height;
+    }
+  };
+
+  return (
+    <>
+      <Tooltip title={t("bottomBar.record")} placement="right">
+        <IconButton
+          color={
+            viewerState.isProcessingVideo
+              ? "warning"
+              : viewerState.isRecordingVideo
+              ? "error"
+              : "primary"
+          }
+          disabled={viewerState.isProcessingVideo}
+          onClick={() => {
+            if (!viewerState.isRecordingVideo) handleOpen();
+            else videoRecorderRef.current.stopRecording();
+          }}
+        >
+          <VideoCameraFrontTwoToneIcon />
+        </IconButton>
+      </Tooltip>
+
+      <Dialog open={open} onClose={handleClose} aria-labelledby="recording-dialog">
+        <DialogTitle>{t("bottomBar.record")}</DialogTitle>
+
+        <DialogContent sx={{ minWidth: 300 }}>
+          <FormControl fullWidth margin="dense">
+            <InputLabel>Video Format</InputLabel>
+            <Select
+              value={selectedFormat}
+              label="Video Format"
+              onChange={(e) => handleFormatChange(e.target.value)}
+            >
+              {videoFormats.map((fmt) => (
+                <MenuItem key={fmt.value} value={fmt.value}>
+                  {fmt.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl fullWidth margin="dense" sx={{ marginTop: 2 }}>
+            <InputLabel>Select Resolution</InputLabel>
+            <Select
+              value={selectedResolution}
+              label="Select Resolution"
+              onChange={(e) => handleResolutionChange(e.target.value)}
+            >
+              {resolutions.map((res) => (
+                <MenuItem key={res.label} value={res.label}>
+                  {res.label} ({res.width}×{res.height})
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </DialogContent>
+
+        <DialogActions>
+          <Button onClick={handleRecord}>Record</Button>
+          <Button onClick={handleClose}>Cancel</Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default observer(RecordingModal);

--- a/src/components/Components/SnapShotModal.tsx
+++ b/src/components/Components/SnapShotModal.tsx
@@ -13,8 +13,6 @@ interface FormData {
   transparent_background: string
 }
 
-
-
 const SnapShotModal: React.FC<{open:boolean}> = () => {
   const { t } = useTranslation();
   const [open, setOpen] = React.useState(false);

--- a/src/components/Components/VideoRecorder.tsx
+++ b/src/components/Components/VideoRecorder.tsx
@@ -251,7 +251,7 @@ function VideoRecorder(props: VideoRecorderViewProps) {
       const frameDuration = 1000 / fps;
 
       const currentAnimationIndex = viewerState.currentAnimationIndex;
-      if (currentAnimationIndex === -1) {
+      if (currentAnimationIndex === -1 && !curState.isGuiMode) {
         enqueueSnackbar(t('snackbars.no_animation_selected'), {
           variant: 'error',
           anchorOrigin: { horizontal: 'right', vertical: 'bottom' },
@@ -260,9 +260,9 @@ function VideoRecorder(props: VideoRecorderViewProps) {
         return;
       }
 
-      const currentAnimation = viewerState.animations[currentAnimationIndex];
-      animationDurationRef.current = currentAnimation.duration;
-
+      else if (curState.isGuiMode && curState.guiHasAnimation) {
+        animationDurationRef.current = curState.guiAnimationEndTime - curState.guiAnimationStartTime;
+      }
       // Set up camera and renderer FIRST, before saving original state
       const { width: targetW, height: targetH } = setupCameraAndRendererForRecording();
 
@@ -282,7 +282,7 @@ function VideoRecorder(props: VideoRecorderViewProps) {
       viewerState.setIsRecordingVideo(true);
       viewerState.setAnimating(false);
       if (curState.isGuiMode) {
-        curState.startGUIAnimationIfAvailable(0.);
+        curState.startGUIAnimationIfAvailable(frameDuration);
       }
       enqueueSnackbar(t('snackbars.recording_video'), {
         variant: 'info',

--- a/src/components/Components/VideoRecorder.tsx
+++ b/src/components/Components/VideoRecorder.tsx
@@ -1,4 +1,3 @@
-
 import * as React from "react";
 import { useEffect, useRef } from "react";
 
@@ -34,7 +33,8 @@ function VideoRecorder(props: VideoRecorderViewProps) {
 
   const capturedFrames = useRef<string[]>([]);
   const isRecordingRef = useRef(false);
-  const fps = 30;
+  const animationDurationRef = useRef(0);
+  const startAnimationTimeRef = useRef(0);
 
   const load = async () => {
     const ffmpeg = ffmpegRef.current;
@@ -52,7 +52,7 @@ function VideoRecorder(props: VideoRecorderViewProps) {
     const preserveAspect = viewerState.videoRecorderPreserveAspectRatio;
     const canvasAspect = glCanvas.width / glCanvas.height;
 
-    // Target resolution from viewerState
+     // Target resolution from viewerState
     const targetW = viewerState.videoRecorderWidth || glCanvas.width;
     const targetH = preserveAspect ? Math.round(targetW / canvasAspect) : (viewerState.videoRecorderHeight || glCanvas.height);
 
@@ -120,16 +120,15 @@ function VideoRecorder(props: VideoRecorderViewProps) {
     // Determine the same target size used in captureFrame()
     const preserveAspect = viewerState.videoRecorderPreserveAspectRatio;
     const canvasAspect = glCanvas.width / glCanvas.height;
+
+    // Ensure even numbers for YUV420p encoding
     const targetW = viewerState.videoRecorderWidth || glCanvas.width;
     const targetH = preserveAspect
       ? Math.round(targetW / canvasAspect)
       : (viewerState.videoRecorderHeight || glCanvas.height);
 
-    // Ensure even numbers for YUV420p encoding
     const evenW = targetW % 2 === 0 ? targetW : targetW - 1;
     const evenH = targetH % 2 === 0 ? targetH : targetH - 1;
-
-    console.log(`Encoding video at ${evenW}x${evenH}`);
 
     // Clean up previous files
     try {
@@ -152,6 +151,7 @@ function VideoRecorder(props: VideoRecorderViewProps) {
     }
 
     // Encoding args
+    const fps = viewerState.recordedVideoFPS || 30;
     const args = [
       '-framerate', `${fps}`,
       '-i', 'input%03d.jpg',
@@ -160,6 +160,7 @@ function VideoRecorder(props: VideoRecorderViewProps) {
     ];
 
     if (ext === 'webm') {
+
       // Encoding args webm
       args.push(
         '-c:v', 'libvpx',
@@ -197,6 +198,24 @@ function VideoRecorder(props: VideoRecorderViewProps) {
     gl.setClearColor(0xffffff, 1);
 
     const startRecording = () => {
+      const fps = viewerState.recordedVideoFPS || 30;
+      const frameDuration = 1000 / fps; // ms per frame
+
+      // Get animation duration from current animation
+      const currentAnimationIndex = viewerState.currentAnimationIndex;
+      if (currentAnimationIndex === -1) {
+        enqueueSnackbar(t('snackbars.no_animation_selected'), { variant: 'error' });
+        return;
+      }
+
+      const currentAnimation = viewerState.animations[currentAnimationIndex];
+      animationDurationRef.current = currentAnimation.duration;
+
+      // Calculate total frames needed for the entire animation
+      const totalFrames = Math.ceil(animationDurationRef.current * fps);
+
+      console.log(`Recording: ${totalFrames} frames at ${fps} FPS, duration: ${animationDurationRef.current.toFixed(2)}s`);
+
       viewerState.setIsRecordingVideo(true);
       viewerState.setAnimating(false);
 
@@ -207,14 +226,11 @@ function VideoRecorder(props: VideoRecorderViewProps) {
       });
 
       capturedFrames.current = [];
-      curState.setCurrentFrame(0);
       isRecordingRef.current = true;
+      startAnimationTimeRef.current = viewerState.currentAnimationTime;
 
       let frameCount = 0;
-      let prevFrame = 0;
-      const startTime = performance.now();
-      let lastCaptureTime = startTime;
-      const frameDuration = 1000 / fps;
+      let lastCaptureTime = 0;
       let isCapturing = false;
 
       const captureAndPush = () => {
@@ -228,49 +244,67 @@ function VideoRecorder(props: VideoRecorderViewProps) {
       };
 
       const recordLoop = async () => {
-        while (isRecordingRef.current) {
+        const startTime = performance.now();
+        lastCaptureTime = startTime;
+
+        while (isRecordingRef.current && frameCount < totalFrames) {
           const now = performance.now();
-          if (now - lastCaptureTime < frameDuration) {
+          const elapsedTime = now - lastCaptureTime;
+
+          // Wait until next frame is due
+          if (elapsedTime < frameDuration) {
             await new Promise<void>(r => requestAnimationFrame(() => r()));
             continue;
           }
-          lastCaptureTime = performance.now();
 
-          if (curState.currentFrame + 1 > 99) {
-            curState.setCurrentFrame(0);
-          } else {
-            curState.incrementCurrentFrame();
-          }
+          lastCaptureTime = now;
 
-          const frame = curState.currentFrame;
-          if (frame < prevFrame) {
-            console.log("Frame wrapped — stopping recording");
-            stopRecording();
-            break;
-          }
-          prevFrame = frame;
+          // Calculate exact animation time for this frame
+          const currentFrameTime = (frameCount / fps);
 
-          await new Promise<void>(r => requestAnimationFrame(() => r()));
+          // Set the exact animation time
+          viewerState.setCurrentAnimationTime(currentFrameTime);
+
+          // Update frame percentage for UI
+          const framePercentage = (currentFrameTime / animationDurationRef.current) * 100;
+          curState.setCurrentFrame(Math.min(framePercentage, 100));
 
           if (!isCapturing) {
             isCapturing = true;
-            try { captureAndPush(); } finally { isCapturing = false; }
+            try {
+              captureAndPush();
+            } finally {
+              isCapturing = false;
+            }
           }
 
-          await new Promise<void>(r => setTimeout(() => r(), 0));
+          // Check if we've reached the end of the animation
+          if (frameCount >= totalFrames) {
+            console.log("Animation complete — stopping recording");
+            stopRecording();
+            break;
+          }
+
+          await new Promise<void>(r => requestAnimationFrame(() => r()));
+        }
+
+        // If we exit the loop for other reasons, stop recording
+        if (isRecordingRef.current) {
+          stopRecording();
         }
 
         const endTime = performance.now();
         const durationSec = (endTime - startTime) / 1000;
         const realFps = frameCount / durationSec;
-        console.log('Recording stopped.');
-        console.log(`Duration: ${durationSec.toFixed(2)}s, Frames: ${frameCount}, FPS: ${realFps.toFixed(2)}`);
+        console.log(`Recording complete. Duration: ${durationSec.toFixed(2)}s, Frames: ${frameCount}, FPS: ${realFps.toFixed(2)}`);
       };
 
       recordLoop();
     };
 
     const stopRecording = async () => {
+      if (!isRecordingRef.current) return;
+
       closeSnackbar();
       viewerState.setIsRecordingVideo(false);
       viewerState.setAnimating(false);
@@ -291,16 +325,21 @@ function VideoRecorder(props: VideoRecorderViewProps) {
         downloadVideo(url, `${viewerState.recordedVideoName}_${timestamp}.${ext}`);
       } catch (e) {
         console.error(e);
+        enqueueSnackbar("Error:", { variant: 'error' });
       }
 
       capturedFrames.current = [];
       viewerState.setIsProcessingVideo(false);
       closeSnackbar();
+
+      // Reset animation time to start
+      viewerState.setCurrentAnimationTime(0);
+      curState.setCurrentFrame(0);
     };
 
     props.videoRecorderRef.current = { startRecording, stopRecording };
 
-  }, [props.videoRecorderRef, gl.domElement, enqueueSnackbar, closeSnackbar, t, viewerState, viewerState.recordedVideoFormat]);
+  }, [props.videoRecorderRef, gl.domElement, enqueueSnackbar, closeSnackbar, t, viewerState, curState, gl]);
 
   return null;
 }

--- a/src/components/Components/VideoRecorder.tsx
+++ b/src/components/Components/VideoRecorder.tsx
@@ -1,17 +1,14 @@
 import * as React from "react";
 import { useEffect, useRef } from "react";
-
 import { observer } from "mobx-react";
 import { useThree } from '@react-three/fiber';
-
 import { FFmpeg } from '@ffmpeg/ffmpeg';
 import { fetchFile } from '@ffmpeg/util';
-
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import { useModelContext } from "../../state/ModelUIStateContext";
-
 import { getTimestamp } from "../../helpers/timeHelpers";
+import { PerspectiveCamera } from 'three';
 
 type VideoRecorderRef = {
   startRecording: () => void;
@@ -20,12 +17,49 @@ type VideoRecorderRef = {
 
 type VideoRecorderViewProps = {
   videoRecorderRef: React.MutableRefObject<VideoRecorderRef | null>;
-}
+};
+
+// Aspect ratio utility functions
+const parseAspectRatio = (aspectRatio: string): { width: number; height: number } => {
+  const [widthStr, heightStr] = aspectRatio.split(':');
+  return {
+    width: parseInt(widthStr, 10),
+    height: parseInt(heightStr, 10)
+  };
+};
+
+const calculateDimensionsFromAspectRatio = (
+  baseDimension: number,
+  aspectRatio: string,
+  useWidthAsBase: boolean = true
+): { width: number; height: number } => {
+  const { width: ratioW, height: ratioH } = parseAspectRatio(aspectRatio);
+  const aspect = ratioW / ratioH;
+
+  if (useWidthAsBase) {
+    return {
+      width: baseDimension,
+      height: Math.round(baseDimension / aspect)
+    };
+  } else {
+    return {
+      width: Math.round(baseDimension * aspect),
+      height: baseDimension
+    };
+  }
+};
+
+const ensureEvenDimensions = (width: number, height: number): { width: number; height: number } => {
+  return {
+    width: width % 2 === 0 ? width : width - 1,
+    height: height % 2 === 0 ? height : height - 1
+  };
+};
 
 function VideoRecorder(props: VideoRecorderViewProps) {
   const { t } = useTranslation();
   const viewerState = useModelContext().viewerState;
-  const { gl } = useThree();
+  const { gl, size, camera } = useThree();
   const curState = useModelContext();
 
   const ffmpegRef = useRef(new FFmpeg());
@@ -35,6 +69,10 @@ function VideoRecorder(props: VideoRecorderViewProps) {
   const isRecordingRef = useRef(false);
   const animationDurationRef = useRef(0);
   const startAnimationTimeRef = useRef(0);
+
+  const originalCameraAspectRef = useRef<number | null>(null);
+  const originalCameraFovRef = useRef<number | null>(null);
+  const originalRendererSizeRef = useRef<{ width: number; height: number } | null>(null);
 
   const load = async () => {
     const ffmpeg = ffmpegRef.current;
@@ -47,64 +85,97 @@ function VideoRecorder(props: VideoRecorderViewProps) {
     }
   };
 
+  const getTargetDimensions = (): { width: number; height: number } => {
+    const glCanvas = gl.domElement;
+
+    // Always use aspect ratio to determine dimensions
+    if (viewerState.recordedVideoAspectRatio) {
+      const { width: ratioW, height: ratioH } = parseAspectRatio(viewerState.recordedVideoAspectRatio);
+      const aspect = ratioW / ratioH;
+
+      // Use base dimension as the primary dimension
+      const baseDimension = viewerState.videoRecorderBaseDimension || 720;
+
+      // For landscape (width >= height), prioritize width
+      // For portrait (height > width), prioritize height
+      if (ratioW >= ratioH) {
+        // Landscape or square - prioritize width
+        const width = baseDimension;
+        const height = Math.round(width / aspect);
+        return ensureEvenDimensions(width, height);
+      } else {
+        // Portrait - prioritize height
+        const height = baseDimension;
+        const width = Math.round(height * aspect);
+        return ensureEvenDimensions(width, height);
+      }
+    }
+
+    // Fallback: use canvas dimensions
+    return {
+      width: glCanvas.width,
+      height: glCanvas.height
+    };
+  };
+
+  const setupCameraAndRendererForRecording = () => {
+    const perspectiveCamera = camera as PerspectiveCamera;
+
+    // Save original state
+    originalCameraAspectRef.current = perspectiveCamera.aspect;
+    originalCameraFovRef.current = perspectiveCamera.fov;
+    originalRendererSizeRef.current = { width: size.width, height: size.height };
+
+    // Get target dimensions for recording
+    const { width: targetW, height: targetH } = getTargetDimensions();
+    const { width: evenW, height: evenH } = ensureEvenDimensions(targetW, targetH);
+
+    console.log(`Setting up recording: ${evenW}x${evenH}, aspect ratio: ${viewerState.recordedVideoAspectRatio}`);
+
+    // Update camera aspect ratio and projection matrix
+    perspectiveCamera.aspect = evenW / evenH;
+    perspectiveCamera.updateProjectionMatrix();
+
+    // Update renderer size
+    gl.setSize(evenW, evenH, false);
+    gl.setPixelRatio(1); // Ensure crisp rendering at exact dimensions
+
+    return { width: evenW, height: evenH };
+  };
+
+  const restoreCameraAndRenderer = () => {
+    if (originalCameraAspectRef.current !== null) {
+      const perspectiveCamera = camera as PerspectiveCamera;
+
+      perspectiveCamera.aspect = originalCameraAspectRef.current;
+      perspectiveCamera.updateProjectionMatrix();
+
+      originalCameraAspectRef.current = null;
+    }
+
+    if (originalRendererSizeRef.current) {
+      gl.setSize(originalRendererSizeRef.current.width, originalRendererSizeRef.current.height, false);
+      originalRendererSizeRef.current = null;
+    }
+  };
+
   const captureFrameReadPixels = (): string => {
     const glCanvas = gl.domElement;
-    const preserveAspect = viewerState.videoRecorderPreserveAspectRatio;
-    const canvasAspect = glCanvas.width / glCanvas.height;
+    const { width: targetW, height: targetH } = getTargetDimensions();
+    const { width: evenW, height: evenH } = ensureEvenDimensions(targetW, targetH);
 
-     // Target resolution from viewerState
-    const targetW = viewerState.videoRecorderWidth || glCanvas.width;
-    const targetH = preserveAspect ? Math.round(targetW / canvasAspect) : (viewerState.videoRecorderHeight || glCanvas.height);
-
-    // Create offscreen 2D canvas at desired resolution
+    // Create offscreen canvas for rendering
     const compositeCanvas = document.createElement('canvas');
-    compositeCanvas.width = targetW;
-    compositeCanvas.height = targetH;
+    compositeCanvas.width = evenW;
+    compositeCanvas.height = evenH;
     const ctx = compositeCanvas.getContext('2d')!;
 
-    // Fill with white before drawing WebGL frame
+    // Set white background
     ctx.fillStyle = '#ffffff';
-    ctx.fillRect(0, 0, targetW, targetH);
+    ctx.fillRect(0, 0, evenW, evenH);
 
-    // Draw WebGL canvas (flattens transparency)
-    const glCtx: WebGLRenderingContext | WebGL2RenderingContext = (gl as any).getContext ? (gl as any).getContext() : (gl as any).context;
-    if (!glCtx) {
-      ctx.drawImage(glCanvas, 0, 0, targetW, targetH);
-      return compositeCanvas.toDataURL('image/jpeg', 0.92);
-    }
-
-    if (typeof (glCtx as any).finish === 'function') {
-      try { (glCtx as any).finish(); } catch (e) {}
-    }
-
-    const w = glCanvas.width;
-    const h = glCanvas.height;
-    const pixels = new Uint8Array(w * h * 4);
-
-    try {
-      glCtx.pixelStorei(glCtx.PACK_ALIGNMENT, 1);
-      glCtx.readPixels(0, 0, w, h, glCtx.RGBA, glCtx.UNSIGNED_BYTE, pixels);
-    } catch (e) {
-      console.warn('readPixels failed, fallback to drawImage', e);
-      ctx.drawImage(glCanvas, 0, 0, targetW, targetH);
-      return compositeCanvas.toDataURL('image/jpeg', 0.92);
-    }
-
-    const rowSize = w * 4;
-    const flipped = new Uint8ClampedArray(pixels.length);
-    for (let y = 0; y < h; y++) {
-      const srcStart = y * rowSize;
-      const dstStart = (h - 1 - y) * rowSize;
-      flipped.set(pixels.subarray(srcStart, srcStart + rowSize), dstStart);
-    }
-
-    const tmp = document.createElement('canvas');
-    tmp.width = w;
-    tmp.height = h;
-    const tmpCtx = tmp.getContext('2d')!;
-    tmpCtx.putImageData(new ImageData(flipped, w, h), 0, 0);
-
-    ctx.drawImage(tmp, 0, 0, targetW, targetH);
+    // Draw the WebGL canvas content
+    ctx.drawImage(glCanvas, 0, 0, evenW, evenH);
 
     // Encode as JPEG (no alpha)
     return compositeCanvas.toDataURL('image/jpeg', 0.92);
@@ -114,23 +185,11 @@ function VideoRecorder(props: VideoRecorderViewProps) {
     const ffmpeg = ffmpegRef.current;
     await load();
 
-    // Clean up any previous files
-    const glCanvas = gl.domElement;
+    const { width: targetW, height: targetH } = getTargetDimensions();
+    const { width: evenW, height: evenH } = ensureEvenDimensions(targetW, targetH);
 
-    // Determine the same target size used in captureFrame()
-    const preserveAspect = viewerState.videoRecorderPreserveAspectRatio;
-    const canvasAspect = glCanvas.width / glCanvas.height;
+    console.log(`Encoding video at ${evenW}x${evenH} (aspect ratio: ${viewerState.recordedVideoAspectRatio})`);
 
-    // Ensure even numbers for YUV420p encoding
-    const targetW = viewerState.videoRecorderWidth || glCanvas.width;
-    const targetH = preserveAspect
-      ? Math.round(targetW / canvasAspect)
-      : (viewerState.videoRecorderHeight || glCanvas.height);
-
-    const evenW = targetW % 2 === 0 ? targetW : targetW - 1;
-    const evenH = targetH % 2 === 0 ? targetH : targetH - 1;
-
-    // Clean up previous files
     try {
       const files = await ffmpeg.listDir('/');
       for (const file of files) {
@@ -142,7 +201,7 @@ function VideoRecorder(props: VideoRecorderViewProps) {
       console.warn("Cleanup skipped:", e);
     }
 
-    // Write new frames
+    // Write all frames to FFmpeg
     for (let i = 0; i < capturedFrames.current.length; i++) {
       const dataURL = capturedFrames.current[i];
       const res = await fetch(dataURL);
@@ -150,34 +209,24 @@ function VideoRecorder(props: VideoRecorderViewProps) {
       await ffmpeg.writeFile(`input${String(i).padStart(3, '0')}.jpg`, await fetchFile(blob));
     }
 
-    // Encoding args
     const fps = viewerState.recordedVideoFPS || 30;
+
+    // FFmpeg arguments - ensure correct aspect ratio and no distortion
     const args = [
       '-framerate', `${fps}`,
       '-i', 'input%03d.jpg',
       '-r', `${fps}`,
-      '-vf', `scale=${evenW}:${evenH}:force_original_aspect_ratio=decrease,pad=${evenW}:${evenH}:(ow-iw)/2:(oh-ih)/2:white`
+      '-vf', `scale=${evenW}:${evenH}:flags=lanczos:force_original_aspect_ratio=disable`
     ];
 
     if (ext === 'webm') {
-
-      // Encoding args webm
-      args.push(
-        '-c:v', 'libvpx',
-        '-b:v', '4M',
-        '-pix_fmt', 'yuv420p'
-      );
+      args.push('-c:v', 'libvpx', '-b:v', '4M', '-pix_fmt', 'yuv420p');
     } else {
-      args.push(
-        '-c:v', 'libx264',
-        '-pix_fmt', 'yuv420p',
-        '-preset', 'fast',
-        '-crf', '17'
-      );
+      args.push('-c:v', 'libx264', '-pix_fmt', 'yuv420p', '-preset', 'fast', '-crf', '17');
       if (ext === 'mov') args.push('-profile:v', 'high');
     }
 
-    args.push(`output.${ext}`);
+    args.push('-y', `output.${ext}`);
     await ffmpeg.exec(args);
 
     const data = await ffmpeg.readFile(`output.${ext}`);
@@ -199,9 +248,8 @@ function VideoRecorder(props: VideoRecorderViewProps) {
 
     const startRecording = () => {
       const fps = viewerState.recordedVideoFPS || 30;
-      const frameDuration = 1000 / fps; // ms per frame
+      const frameDuration = 1000 / fps;
 
-      // Get animation duration from current animation
       const currentAnimationIndex = viewerState.currentAnimationIndex;
       if (currentAnimationIndex === -1) {
         enqueueSnackbar(t('snackbars.no_animation_selected'), { variant: 'error' });
@@ -211,10 +259,21 @@ function VideoRecorder(props: VideoRecorderViewProps) {
       const currentAnimation = viewerState.animations[currentAnimationIndex];
       animationDurationRef.current = currentAnimation.duration;
 
-      // Calculate total frames needed for the entire animation
-      const totalFrames = Math.ceil(animationDurationRef.current * fps);
+      // Set up camera and renderer FIRST, before saving original state
+      const { width: targetW, height: targetH } = setupCameraAndRendererForRecording();
 
-      console.log(`Recording: ${totalFrames} frames at ${fps} FPS, duration: ${animationDurationRef.current.toFixed(2)}s`);
+      console.log(`First recording setup: ${targetW}x${targetH}, aspect: ${viewerState.recordedVideoAspectRatio}`);
+
+      // Give the renderer a moment to complete the resize
+      setTimeout(() => {
+        startCaptureProcess();
+      }, 100);
+    };
+
+    const startCaptureProcess = () => {
+      const fps = viewerState.recordedVideoFPS || 30;
+      const frameDuration = 1000 / fps;
+      const totalFrames = Math.ceil(animationDurationRef.current * fps);
 
       viewerState.setIsRecordingVideo(true);
       viewerState.setAnimating(false);
@@ -222,7 +281,7 @@ function VideoRecorder(props: VideoRecorderViewProps) {
       enqueueSnackbar(t('snackbars.recording_video'), {
         variant: 'info',
         anchorOrigin: { horizontal: 'right', vertical: 'bottom' },
-        persist: true,
+        persist: true
       });
 
       capturedFrames.current = [];
@@ -238,6 +297,7 @@ function VideoRecorder(props: VideoRecorderViewProps) {
           const frameDataURL = captureFrameReadPixels();
           capturedFrames.current.push(frameDataURL);
           frameCount++;
+          console.log(`Captured frame ${frameCount}/${totalFrames}`);
         } catch (e) {
           console.error('Capture failed', e);
         }
@@ -247,22 +307,28 @@ function VideoRecorder(props: VideoRecorderViewProps) {
         const startTime = performance.now();
         lastCaptureTime = startTime;
 
+        // CAPTURE THE FIRST FRAME IMMEDIATELY with proper setup
+        if (frameCount === 0) {
+          viewerState.setCurrentAnimationTime(0);
+          curState.setCurrentFrame(0);
+          captureAndPush();
+          frameCount++;
+          lastCaptureTime = performance.now();
+        }
+
         while (isRecordingRef.current && frameCount < totalFrames) {
           const now = performance.now();
           const elapsedTime = now - lastCaptureTime;
 
           // Wait until next frame is due
+
           if (elapsedTime < frameDuration) {
             await new Promise<void>(r => requestAnimationFrame(() => r()));
             continue;
           }
 
           lastCaptureTime = now;
-
-          // Calculate exact animation time for this frame
-          const currentFrameTime = (frameCount / fps);
-
-          // Set the exact animation time
+          const currentFrameTime = frameCount / fps;
           viewerState.setCurrentAnimationTime(currentFrameTime);
 
           // Update frame percentage for UI
@@ -288,15 +354,7 @@ function VideoRecorder(props: VideoRecorderViewProps) {
           await new Promise<void>(r => requestAnimationFrame(() => r()));
         }
 
-        // If we exit the loop for other reasons, stop recording
-        if (isRecordingRef.current) {
-          stopRecording();
-        }
-
-        const endTime = performance.now();
-        const durationSec = (endTime - startTime) / 1000;
-        const realFps = frameCount / durationSec;
-        console.log(`Recording complete. Duration: ${durationSec.toFixed(2)}s, Frames: ${frameCount}, FPS: ${realFps.toFixed(2)}`);
+        if (isRecordingRef.current) stopRecording();
       };
 
       recordLoop();
@@ -308,13 +366,15 @@ function VideoRecorder(props: VideoRecorderViewProps) {
       closeSnackbar();
       viewerState.setIsRecordingVideo(false);
       viewerState.setAnimating(false);
-
       isRecordingRef.current = false;
+
+      // Restore original camera and renderer settings
+      restoreCameraAndRenderer();
 
       enqueueSnackbar(t('snackbars.processing_video'), {
         variant: 'info',
         anchorOrigin: { horizontal: 'right', vertical: 'bottom' },
-        persist: true,
+        persist: true
       });
       viewerState.setIsProcessingVideo(true);
 
@@ -325,21 +385,19 @@ function VideoRecorder(props: VideoRecorderViewProps) {
         downloadVideo(url, `${viewerState.recordedVideoName}_${timestamp}.${ext}`);
       } catch (e) {
         console.error(e);
-        enqueueSnackbar("Error:", { variant: 'error' });
+        enqueueSnackbar("Error processing video", { variant: 'error' });
       }
 
       capturedFrames.current = [];
       viewerState.setIsProcessingVideo(false);
       closeSnackbar();
 
-      // Reset animation time to start
       viewerState.setCurrentAnimationTime(0);
       curState.setCurrentFrame(0);
     };
 
     props.videoRecorderRef.current = { startRecording, stopRecording };
-
-  }, [props.videoRecorderRef, gl.domElement, enqueueSnackbar, closeSnackbar, t, viewerState, curState, gl]);
+  }, [props.videoRecorderRef, gl, camera, size, enqueueSnackbar, closeSnackbar, t, viewerState, curState]);
 
   return null;
 }

--- a/src/components/Components/VideoRecorder.tsx
+++ b/src/components/Components/VideoRecorder.tsx
@@ -252,7 +252,11 @@ function VideoRecorder(props: VideoRecorderViewProps) {
 
       const currentAnimationIndex = viewerState.currentAnimationIndex;
       if (currentAnimationIndex === -1) {
-        enqueueSnackbar(t('snackbars.no_animation_selected'), { variant: 'error' });
+        enqueueSnackbar(t('snackbars.no_animation_selected'), {
+          variant: 'error',
+          anchorOrigin: { horizontal: 'right', vertical: 'bottom' },
+          autoHideDuration: 5000, // 5 seconds
+        });
         return;
       }
 

--- a/src/components/Components/VideoRecorder.tsx
+++ b/src/components/Components/VideoRecorder.tsx
@@ -262,6 +262,9 @@ function VideoRecorder(props: VideoRecorderViewProps) {
 
       else if (curState.isGuiMode && curState.guiHasAnimation) {
         animationDurationRef.current = curState.guiAnimationEndTime - curState.guiAnimationStartTime;
+        if (curState.guiAnimationSpeed !== 1.0) {
+          animationDurationRef.current /= curState.guiAnimationSpeed;
+        }
       }
       // Set up camera and renderer FIRST, before saving original state
       const { width: targetW, height: targetH } = setupCameraAndRendererForRecording();

--- a/src/components/Components/VideoRecorder.tsx
+++ b/src/components/Components/VideoRecorder.tsx
@@ -199,7 +199,9 @@ function VideoRecorder(props: VideoRecorderViewProps) {
     const startRecording = () => {
       viewerState.setIsRecordingVideo(true);
       viewerState.setAnimating(false);
-
+      if (curState.isGuiMode) {
+        curState.startGUIAnimationIfAvailable(0.);
+      }
       enqueueSnackbar(t('snackbars.recording_video'), {
         variant: 'info',
         anchorOrigin: { horizontal: 'right', vertical: 'bottom' },

--- a/src/components/Components/VideoRecorder.tsx
+++ b/src/components/Components/VideoRecorder.tsx
@@ -1,3 +1,4 @@
+
 import * as React from "react";
 import { useEffect, useRef } from "react";
 
@@ -35,22 +36,19 @@ function VideoRecorder(props: VideoRecorderViewProps) {
   const isRecordingRef = useRef(false);
   const fps = 30;
 
-  // Load ffmpeg.wasm
   const load = async () => {
     const ffmpeg = ffmpegRef.current;
     ffmpeg.on('log', ({ message }) => console.log(message));
-    await ffmpeg.load({
-      coreURL: '/ffmpeg/ffmpeg-core.js',
-      wasmURL: '/ffmpeg/ffmpeg-core.wasm',
-    });
+    if (!ffmpeg.loaded) {
+      await ffmpeg.load({
+        coreURL: '/ffmpeg/ffmpeg-core.js',
+        wasmURL: '/ffmpeg/ffmpeg-core.wasm',
+      });
+    }
   };
 
-  /**
-   * Capture the current WebGL frame and flatten transparency to white.
-   */
-  const captureFrame = (): string => {
+  const captureFrameReadPixels = (): string => {
     const glCanvas = gl.domElement;
-
     const preserveAspect = viewerState.videoRecorderPreserveAspectRatio;
     const canvasAspect = glCanvas.width / glCanvas.height;
 
@@ -69,13 +67,50 @@ function VideoRecorder(props: VideoRecorderViewProps) {
     ctx.fillRect(0, 0, targetW, targetH);
 
     // Draw WebGL canvas (flattens transparency)
-    ctx.drawImage(glCanvas, 0, 0, targetW, targetH);
+    const glCtx: WebGLRenderingContext | WebGL2RenderingContext = (gl as any).getContext ? (gl as any).getContext() : (gl as any).context;
+    if (!glCtx) {
+      ctx.drawImage(glCanvas, 0, 0, targetW, targetH);
+      return compositeCanvas.toDataURL('image/jpeg', 0.92);
+    }
+
+    if (typeof (glCtx as any).finish === 'function') {
+      try { (glCtx as any).finish(); } catch (e) {}
+    }
+
+    const w = glCanvas.width;
+    const h = glCanvas.height;
+    const pixels = new Uint8Array(w * h * 4);
+
+    try {
+      glCtx.pixelStorei(glCtx.PACK_ALIGNMENT, 1);
+      glCtx.readPixels(0, 0, w, h, glCtx.RGBA, glCtx.UNSIGNED_BYTE, pixels);
+    } catch (e) {
+      console.warn('readPixels failed, fallback to drawImage', e);
+      ctx.drawImage(glCanvas, 0, 0, targetW, targetH);
+      return compositeCanvas.toDataURL('image/jpeg', 0.92);
+    }
+
+    const rowSize = w * 4;
+    const flipped = new Uint8ClampedArray(pixels.length);
+    for (let y = 0; y < h; y++) {
+      const srcStart = y * rowSize;
+      const dstStart = (h - 1 - y) * rowSize;
+      flipped.set(pixels.subarray(srcStart, srcStart + rowSize), dstStart);
+    }
+
+    const tmp = document.createElement('canvas');
+    tmp.width = w;
+    tmp.height = h;
+    const tmpCtx = tmp.getContext('2d')!;
+    tmpCtx.putImageData(new ImageData(flipped, w, h), 0, 0);
+
+    ctx.drawImage(tmp, 0, 0, targetW, targetH);
 
     // Encode as JPEG (no alpha)
     return compositeCanvas.toDataURL('image/jpeg', 0.92);
   };
 
-  const encodeFramesToVideo = async (ext: 'mp4' | 'mov') => {
+  const encodeFramesToVideo = async (ext: 'mp4' | 'mov' | 'webm') => {
     const ffmpeg = ffmpegRef.current;
     await load();
 
@@ -121,15 +156,24 @@ function VideoRecorder(props: VideoRecorderViewProps) {
       '-framerate', `${fps}`,
       '-i', 'input%03d.jpg',
       '-r', `${fps}`,
-      '-vf', `scale=${evenW}:${evenH}:force_original_aspect_ratio=decrease,pad=${evenW}:${evenH}:(ow-iw)/2:(oh-ih)/2:white`,
-      '-c:v', 'libx264',
-      '-pix_fmt', 'yuv420p',
-      '-preset', 'fast',
-      '-crf', '17',
+      '-vf', `scale=${evenW}:${evenH}:force_original_aspect_ratio=decrease,pad=${evenW}:${evenH}:(ow-iw)/2:(oh-ih)/2:white`
     ];
 
-    if (ext === 'mov') {
-      args.push('-profile:v', 'high');
+    if (ext === 'webm') {
+      // Encoding args webm
+      args.push(
+        '-c:v', 'libvpx',
+        '-b:v', '4M',
+        '-pix_fmt', 'yuv420p'
+      );
+    } else {
+      args.push(
+        '-c:v', 'libx264',
+        '-pix_fmt', 'yuv420p',
+        '-preset', 'fast',
+        '-crf', '17'
+      );
+      if (ext === 'mov') args.push('-profile:v', 'high');
     }
 
     args.push(`output.${ext}`);
@@ -152,30 +196,6 @@ function VideoRecorder(props: VideoRecorderViewProps) {
     // Ensure the renderer clears to white for MediaRecorder path
     gl.setClearColor(0xffffff, 1);
 
-    const stream = gl.domElement.captureStream(fps);
-    const webmSupported = MediaRecorder.isTypeSupported('video/webm;codecs=vp8,opus');
-    const useMediaRecorder = viewerState.recordedVideoFormat === 'webm' && webmSupported;
-
-    const recorder = useMediaRecorder
-      ? new MediaRecorder(stream, { mimeType: 'video/webm;codecs=vp8,opus' })
-      : null;
-
-    const recordedChunks: Blob[] = [];
-
-    if (recorder) {
-      recorder.ondataavailable = (e) => {
-        if (e.data.size > 0) recordedChunks.push(e.data);
-      };
-
-      recorder.onstop = async () => {
-        const blob = new Blob(recordedChunks, { type: 'video/webm' });
-        const url = URL.createObjectURL(blob);
-        const timestamp = getTimestamp();
-        downloadVideo(url, `${viewerState.recordedVideoName}_${timestamp}.webm`);
-        recordedChunks.length = 0; // cleanup
-      };
-    }
-
     const startRecording = () => {
       viewerState.setIsRecordingVideo(true);
       viewerState.setAnimating(false);
@@ -186,69 +206,68 @@ function VideoRecorder(props: VideoRecorderViewProps) {
         persist: true,
       });
 
+      capturedFrames.current = [];
+      curState.setCurrentFrame(0);
+      isRecordingRef.current = true;
+
+      let frameCount = 0;
       let prevFrame = 0;
+      const startTime = performance.now();
+      let lastCaptureTime = startTime;
+      const frameDuration = 1000 / fps;
+      let isCapturing = false;
 
-      if (useMediaRecorder && recorder) {
-        recordedChunks.length = 0; // reset chunks before starting
-        viewerState.setAnimating(true);
-        recorder.start();
+      const captureAndPush = () => {
+        try {
+          const frameDataURL = captureFrameReadPixels();
+          capturedFrames.current.push(frameDataURL);
+          frameCount++;
+        } catch (e) {
+          console.error('Capture failed', e);
+        }
+      };
 
-        // Check if it is recording, and we have not yet completing
-        // and animation cycle.
-
-        const frameCheck = () => {
-          const frame = curState.currentFrame;
-          if (viewerState.isRecordingVideo && frame < prevFrame) {
-            stopRecording();
-            return;
-          }
-          prevFrame = frame;
-          requestAnimationFrame(frameCheck);
-        };
-
-        requestAnimationFrame(frameCheck);
-      } else {
-        capturedFrames.current = [];
-        viewerState.setAnimating(true);
-        isRecordingRef.current = true;
-
-        let frameCount = 0;
-        const startTime = performance.now();
-        let lastCaptureTime = startTime;
-
-        const loop = () => {
-          if (!isRecordingRef.current) {
-            const endTime = performance.now();
-            const durationSec = (endTime - startTime) / 1000;
-            const realFps = frameCount / durationSec;
-            console.log(`Recording stopped.`);
-            console.log(`Duration: ${durationSec.toFixed(2)}s`);
-            console.log(`Frames: ${frameCount}`);
-            console.log(`FPS: ${realFps.toFixed(2)}`);
-            return;
-          }
-
-          const frame = curState.currentFrame;
-          if (viewerState.isRecordingVideo && frame < prevFrame) {
-            stopRecording();
-            return;
-          }
-          prevFrame = frame;
-
+      const recordLoop = async () => {
+        while (isRecordingRef.current) {
           const now = performance.now();
-          const frameDuration = 1000 / fps;
-          if (now - lastCaptureTime >= frameDuration) {
-            lastCaptureTime = now;
-            const frameDataURL = captureFrame(); // white background flattening here
-            capturedFrames.current.push(frameDataURL);
-            frameCount++;
+          if (now - lastCaptureTime < frameDuration) {
+            await new Promise<void>(r => requestAnimationFrame(() => r()));
+            continue;
+          }
+          lastCaptureTime = performance.now();
+
+          if (curState.currentFrame + 1 > 99) {
+            curState.setCurrentFrame(0);
+          } else {
+            curState.incrementCurrentFrame();
           }
 
-          requestAnimationFrame(loop);
-        };
+          const frame = curState.currentFrame;
+          if (frame < prevFrame) {
+            console.log("Frame wrapped — stopping recording");
+            stopRecording();
+            break;
+          }
+          prevFrame = frame;
 
-        requestAnimationFrame(loop);
-      }
+          await new Promise<void>(r => requestAnimationFrame(() => r()));
+
+          if (!isCapturing) {
+            isCapturing = true;
+            try { captureAndPush(); } finally { isCapturing = false; }
+          }
+
+          await new Promise<void>(r => setTimeout(() => r(), 0));
+        }
+
+        const endTime = performance.now();
+        const durationSec = (endTime - startTime) / 1000;
+        const realFps = frameCount / durationSec;
+        console.log('Recording stopped.');
+        console.log(`Duration: ${durationSec.toFixed(2)}s, Frames: ${frameCount}, FPS: ${realFps.toFixed(2)}`);
+      };
+
+      recordLoop();
     };
 
     const stopRecording = async () => {
@@ -256,34 +275,31 @@ function VideoRecorder(props: VideoRecorderViewProps) {
       viewerState.setIsRecordingVideo(false);
       viewerState.setAnimating(false);
 
-      if (useMediaRecorder && recorder) {
-        recorder.stop();
-      } else {
-        isRecordingRef.current = false;
+      isRecordingRef.current = false;
 
-        enqueueSnackbar(t('snackbars.processing_video'), {
-          variant: 'info',
-          anchorOrigin: { horizontal: 'right', vertical: 'bottom' },
-          persist: true,
-        });
-        viewerState.setIsProcessingVideo(true);
+      enqueueSnackbar(t('snackbars.processing_video'), {
+        variant: 'info',
+        anchorOrigin: { horizontal: 'right', vertical: 'bottom' },
+        persist: true,
+      });
+      viewerState.setIsProcessingVideo(true);
 
-        try {
-          const ext = viewerState.recordedVideoFormat as 'mp4' | 'mov';
-          const url = await encodeFramesToVideo(ext);
-          const timestamp = getTimestamp();
-          downloadVideo(url, `${viewerState.recordedVideoName}_${timestamp}.${ext}`);
-        } catch (e) {
-          console.error(e);
-        }
-
-        capturedFrames.current = []; //cleanup
-        viewerState.setIsProcessingVideo(false);
-        closeSnackbar();
+      try {
+        const ext = viewerState.recordedVideoFormat as 'mp4' | 'mov' | 'webm';
+        const url = await encodeFramesToVideo(ext);
+        const timestamp = getTimestamp();
+        downloadVideo(url, `${viewerState.recordedVideoName}_${timestamp}.${ext}`);
+      } catch (e) {
+        console.error(e);
       }
+
+      capturedFrames.current = [];
+      viewerState.setIsProcessingVideo(false);
+      closeSnackbar();
     };
 
     props.videoRecorderRef.current = { startRecording, stopRecording };
+
   }, [props.videoRecorderRef, gl.domElement, enqueueSnackbar, closeSnackbar, t, viewerState, viewerState.recordedVideoFormat]);
 
   return null;

--- a/src/components/Components/VideoRecorder.tsx
+++ b/src/components/Components/VideoRecorder.tsx
@@ -50,21 +50,26 @@ function VideoRecorder(props: VideoRecorderViewProps) {
    */
   const captureFrame = (): string => {
     const glCanvas = gl.domElement;
-    const w = glCanvas.width;
-    const h = glCanvas.height;
 
-    // Create an offscreen 2D canvas
+    const preserveAspect = viewerState.videoRecorderPreserveAspectRatio;
+    const canvasAspect = glCanvas.width / glCanvas.height;
+
+    // Target resolution from viewerState
+    const targetW = viewerState.videoRecorderWidth || glCanvas.width;
+    const targetH = preserveAspect ? Math.round(targetW / canvasAspect) : (viewerState.videoRecorderHeight || glCanvas.height);
+
+    // Create offscreen 2D canvas at desired resolution
     const compositeCanvas = document.createElement('canvas');
-    compositeCanvas.width = w;
-    compositeCanvas.height = h;
+    compositeCanvas.width = targetW;
+    compositeCanvas.height = targetH;
     const ctx = compositeCanvas.getContext('2d')!;
 
     // Fill with white before drawing WebGL frame
     ctx.fillStyle = '#ffffff';
-    ctx.fillRect(0, 0, w, h);
+    ctx.fillRect(0, 0, targetW, targetH);
 
     // Draw WebGL canvas (flattens transparency)
-    ctx.drawImage(glCanvas, 0, 0, w, h);
+    ctx.drawImage(glCanvas, 0, 0, targetW, targetH);
 
     // Encode as JPEG (no alpha)
     return compositeCanvas.toDataURL('image/jpeg', 0.92);
@@ -75,6 +80,23 @@ function VideoRecorder(props: VideoRecorderViewProps) {
     await load();
 
     // Clean up any previous files
+    const glCanvas = gl.domElement;
+
+    // Determine the same target size used in captureFrame()
+    const preserveAspect = viewerState.videoRecorderPreserveAspectRatio;
+    const canvasAspect = glCanvas.width / glCanvas.height;
+    const targetW = viewerState.videoRecorderWidth || glCanvas.width;
+    const targetH = preserveAspect
+      ? Math.round(targetW / canvasAspect)
+      : (viewerState.videoRecorderHeight || glCanvas.height);
+
+    // Ensure even numbers for YUV420p encoding
+    const evenW = targetW % 2 === 0 ? targetW : targetW - 1;
+    const evenH = targetH % 2 === 0 ? targetH : targetH - 1;
+
+    console.log(`Encoding video at ${evenW}x${evenH}`);
+
+    // Clean up previous files
     try {
       const files = await ffmpeg.listDir('/');
       for (const file of files) {
@@ -99,6 +121,7 @@ function VideoRecorder(props: VideoRecorderViewProps) {
       '-framerate', `${fps}`,
       '-i', 'input%03d.jpg',
       '-r', `${fps}`,
+      '-vf', `scale=${evenW}:${evenH}:force_original_aspect_ratio=decrease,pad=${evenW}:${evenH}:(ow-iw)/2:(oh-ih)/2:white`,
       '-c:v', 'libx264',
       '-pix_fmt', 'yuv420p',
       '-preset', 'fast',
@@ -107,7 +130,6 @@ function VideoRecorder(props: VideoRecorderViewProps) {
 
     if (ext === 'mov') {
       args.push('-profile:v', 'high');
-      args.push('-vf', 'pad=ceil(iw/2)*2:ceil(ih/2)*2');
     }
 
     args.push(`output.${ext}`);

--- a/src/components/Components/VideoRecorder.tsx
+++ b/src/components/Components/VideoRecorder.tsx
@@ -26,9 +26,8 @@ function VideoRecorder(props: VideoRecorderViewProps) {
   const { t } = useTranslation();
   const viewerState = useModelContext().viewerState;
   const { gl } = useThree();
-
   const curState = useModelContext();
-  
+
   const ffmpegRef = useRef(new FFmpeg());
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();
 
@@ -36,6 +35,7 @@ function VideoRecorder(props: VideoRecorderViewProps) {
   const isRecordingRef = useRef(false);
   const fps = 30;
 
+  // Load ffmpeg.wasm
   const load = async () => {
     const ffmpeg = ffmpegRef.current;
     ffmpeg.on('log', ({ message }) => console.log(message));
@@ -45,15 +45,36 @@ function VideoRecorder(props: VideoRecorderViewProps) {
     });
   };
 
+  /**
+   * Capture the current WebGL frame and flatten transparency to white.
+   */
   const captureFrame = (): string => {
-    return gl.domElement.toDataURL('image/jpeg', 0.92);
+    const glCanvas = gl.domElement;
+    const w = glCanvas.width;
+    const h = glCanvas.height;
+
+    // Create an offscreen 2D canvas
+    const compositeCanvas = document.createElement('canvas');
+    compositeCanvas.width = w;
+    compositeCanvas.height = h;
+    const ctx = compositeCanvas.getContext('2d')!;
+
+    // Fill with white before drawing WebGL frame
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, w, h);
+
+    // Draw WebGL canvas (flattens transparency)
+    ctx.drawImage(glCanvas, 0, 0, w, h);
+
+    // Encode as JPEG (no alpha)
+    return compositeCanvas.toDataURL('image/jpeg', 0.92);
   };
 
   const encodeFramesToVideo = async (ext: 'mp4' | 'mov') => {
     const ffmpeg = ffmpegRef.current;
     await load();
 
-    // Clean up old files from previous runs
+    // Clean up any previous files
     try {
       const files = await ffmpeg.listDir('/');
       for (const file of files) {
@@ -73,6 +94,7 @@ function VideoRecorder(props: VideoRecorderViewProps) {
       await ffmpeg.writeFile(`input${String(i).padStart(3, '0')}.jpg`, await fetchFile(blob));
     }
 
+    // Encoding args
     const args = [
       '-framerate', `${fps}`,
       '-i', 'input%03d.jpg',
@@ -105,11 +127,16 @@ function VideoRecorder(props: VideoRecorderViewProps) {
   };
 
   useEffect(() => {
+    // Ensure the renderer clears to white for MediaRecorder path
+    gl.setClearColor(0xffffff, 1);
+
     const stream = gl.domElement.captureStream(fps);
     const webmSupported = MediaRecorder.isTypeSupported('video/webm;codecs=vp8,opus');
     const useMediaRecorder = viewerState.recordedVideoFormat === 'webm' && webmSupported;
 
-    const recorder = useMediaRecorder ? new MediaRecorder(stream, { mimeType: 'video/webm;codecs=vp8,opus' }) : null;
+    const recorder = useMediaRecorder
+      ? new MediaRecorder(stream, { mimeType: 'video/webm;codecs=vp8,opus' })
+      : null;
 
     const recordedChunks: Blob[] = [];
 
@@ -123,7 +150,6 @@ function VideoRecorder(props: VideoRecorderViewProps) {
         const url = URL.createObjectURL(blob);
         const timestamp = getTimestamp();
         downloadVideo(url, `${viewerState.recordedVideoName}_${timestamp}.webm`);
-
         recordedChunks.length = 0; // cleanup
       };
     }
@@ -135,10 +161,10 @@ function VideoRecorder(props: VideoRecorderViewProps) {
       enqueueSnackbar(t('snackbars.recording_video'), {
         variant: 'info',
         anchorOrigin: { horizontal: 'right', vertical: 'bottom' },
-        persist: true
+        persist: true,
       });
 
-      let prevFrame = 0
+      let prevFrame = 0;
 
       if (useMediaRecorder && recorder) {
         recordedChunks.length = 0; // reset chunks before starting
@@ -147,6 +173,7 @@ function VideoRecorder(props: VideoRecorderViewProps) {
 
         // Check if it is recording, and we have not yet completing
         // and animation cycle.
+
         const frameCheck = () => {
           const frame = curState.currentFrame;
           if (viewerState.isRecordingVideo && frame < prevFrame) {
@@ -155,10 +182,9 @@ function VideoRecorder(props: VideoRecorderViewProps) {
           }
           prevFrame = frame;
           requestAnimationFrame(frameCheck);
-        }
+        };
 
         requestAnimationFrame(frameCheck);
-
       } else {
         capturedFrames.current = [];
         viewerState.setAnimating(true);
@@ -168,45 +194,38 @@ function VideoRecorder(props: VideoRecorderViewProps) {
         const startTime = performance.now();
         let lastCaptureTime = startTime;
 
-        const captureLoop = () => {
-          const loop = () => {
-            if (!isRecordingRef.current) {
-              const endTime = performance.now();
-              const durationSec = (endTime - startTime) / 1000;
-              const realFps = frameCount / durationSec;
-              console.log(`Recording stopped.`);
-              console.log(`Duration: ${durationSec.toFixed(2)} seconds`);
-              console.log(`Frames captured: ${frameCount}`);
-              console.log(`Real framerate: ${realFps.toFixed(2)} fps`);
-              return;
-            }
+        const loop = () => {
+          if (!isRecordingRef.current) {
+            const endTime = performance.now();
+            const durationSec = (endTime - startTime) / 1000;
+            const realFps = frameCount / durationSec;
+            console.log(`Recording stopped.`);
+            console.log(`Duration: ${durationSec.toFixed(2)}s`);
+            console.log(`Frames: ${frameCount}`);
+            console.log(`FPS: ${realFps.toFixed(2)}`);
+            return;
+          }
 
-            const frame = curState.currentFrame;
-            if (viewerState.isRecordingVideo && frame < prevFrame) {
-              stopRecording();
-              return;
-            }
-            prevFrame = frame;
+          const frame = curState.currentFrame;
+          if (viewerState.isRecordingVideo && frame < prevFrame) {
+            stopRecording();
+            return;
+          }
+          prevFrame = frame;
 
-            const now = performance.now();
-            const timeSinceLastCapture = now - lastCaptureTime;
-            const frameDuration = 1000 / fps;
-
-            if (timeSinceLastCapture >= frameDuration) {
-              lastCaptureTime = now;
-              const frameDataURL = captureFrame();
-              capturedFrames.current.push(frameDataURL);
-              frameCount++;
-            }
-
-            prevFrame = frame;
-            requestAnimationFrame(loop);
-          };
+          const now = performance.now();
+          const frameDuration = 1000 / fps;
+          if (now - lastCaptureTime >= frameDuration) {
+            lastCaptureTime = now;
+            const frameDataURL = captureFrame(); // white background flattening here
+            capturedFrames.current.push(frameDataURL);
+            frameCount++;
+          }
 
           requestAnimationFrame(loop);
         };
 
-        captureLoop();
+        requestAnimationFrame(loop);
       }
     };
 
@@ -219,10 +238,11 @@ function VideoRecorder(props: VideoRecorderViewProps) {
         recorder.stop();
       } else {
         isRecordingRef.current = false;
+
         enqueueSnackbar(t('snackbars.processing_video'), {
           variant: 'info',
           anchorOrigin: { horizontal: 'right', vertical: 'bottom' },
-          persist: true
+          persist: true,
         });
         viewerState.setIsProcessingVideo(true);
 
@@ -235,7 +255,7 @@ function VideoRecorder(props: VideoRecorderViewProps) {
           console.error(e);
         }
 
-        capturedFrames.current = []; // cleanup
+        capturedFrames.current = []; //cleanup
         viewerState.setIsProcessingVideo(false);
         closeSnackbar();
       }

--- a/src/components/pages/BottomBar.tsx
+++ b/src/components/pages/BottomBar.tsx
@@ -30,6 +30,21 @@ interface BottomBarProps {
   animationBounds?: number[];
 }
 
+// Helper function to format seconds to mm:ss.dd
+const formatTime = (seconds: number): string => {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  const hundredths = Math.floor((seconds % 1) * 100);
+  return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}.${hundredths.toString().padStart(2, '0')}`;
+};
+
+// Helper function to parse mm:ss.dd to seconds
+const parseTime = (timeString: string): number => {
+  const [timePart, hundredthsPart] = timeString.split('.');
+  const [mins, secs] = timePart.split(':').map(Number);
+  const hundredths = hundredthsPart ? Number(hundredthsPart) : 0;
+  return (mins * 60) + (secs || 0) + (hundredths / 100);
+};
 
 const BottomBar = React.forwardRef(function CustomContent(
     props: BottomBarProps,
@@ -42,12 +57,34 @@ const BottomBar = React.forwardRef(function CustomContent(
     const [speed, setSpeed] = useState(1.0);
     const [play, setPlay] = useState(false);
     const [selectedAnim, setSelectedAnim] = useState("");
+    const [currentTimeDisplay, setCurrentTimeDisplay] = useState("00:00.00");
+    const [totalDuration, setTotalDuration] = useState(0);
+    const [totalDurationDisplay, setTotalDurationDisplay] = useState("00:00.00");
     const isExtraSmallScreen = useMediaQuery((theme:any) => theme.breakpoints.only('xs'));
     const isSmallScreen = useMediaQuery((theme:any) => theme.breakpoints.only('sm'));
     const isMediumScreen = useMediaQuery((theme:any) => theme.breakpoints.only('md'));
 
-    const minWidthSlider = isExtraSmallScreen ? 150 : isSmallScreen ? 175 : isMediumScreen ? 250 : 300; // Adjust values as needed
-    const maxWidthTime = 45;
+    const minWidthSlider = isExtraSmallScreen ? 150 : isSmallScreen ? 175 : isMediumScreen ? 250 : 300;
+    const maxWidthTime = 60; // Increased to accommodate mm:ss.dd format
+
+    // Update time display when animation time changes
+    useEffect(() => {
+      if (viewerState.currentAnimationIndex !== -1 && viewerState.animations.length > 0) {
+        const currentTime = viewerState.currentAnimationTime;
+        setCurrentTimeDisplay(formatTime(currentTime));
+
+        // Update total duration when animation changes
+        const currentAnimation = viewerState.animations[viewerState.currentAnimationIndex];
+        if (currentAnimation && currentAnimation.duration !== totalDuration) {
+          setTotalDuration(currentAnimation.duration);
+          setTotalDurationDisplay(formatTime(currentAnimation.duration));
+        }
+      } else {
+        setCurrentTimeDisplay("00:00.00");
+        setTotalDuration(0);
+        setTotalDurationDisplay("00:00.00");
+      }
+    }, [viewerState.currentAnimationTime, viewerState.currentAnimationIndex, viewerState.animations, totalDuration]);
 
     const handleAnimationChange = useCallback((animationName: string, animate: boolean) => {
       const targetName = animationName
@@ -61,6 +98,13 @@ const BottomBar = React.forwardRef(function CustomContent(
       }
       const idx = curState.viewerState.animations.findIndex((value: AnimationClip)=>{return (value.name === targetName)});
       curState.viewerState.setCurrentAnimationIndex(idx);
+
+      // Set total duration for new animation
+      if (idx !== -1) {
+        const animation = curState.viewerState.animations[idx];
+        setTotalDuration(animation.duration);
+        setTotalDurationDisplay(formatTime(animation.duration));
+      }
     }, [curState.viewerState]);
 
     const handleAnimationChangeEvent = (event: SelectChangeEvent) => {
@@ -78,24 +122,71 @@ const BottomBar = React.forwardRef(function CustomContent(
         setSpeed(Number(event.target.value))
     }
 
-    const handleBlur = () => {
-      if (curState.currentFrame < 0) {
-        curState.setCurrentFrame(0);
-      } else if (curState.currentFrame > 100) {
-        curState.setCurrentFrame(100);
+    const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (viewerState.currentAnimationIndex === -1) return;
+
+      const timeString = event.target.value;
+      setCurrentTimeDisplay(timeString);
+    };
+
+    const handleInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+      if (viewerState.currentAnimationIndex === -1) return;
+
+      const timeString = event.target.value;
+      if (/^\d{1,2}:\d{2}\.\d{2}$/.test(timeString)) {
+        const newTime = parseTime(timeString);
+        const currentAnimation = viewerState.animations[viewerState.currentAnimationIndex];
+        if (currentAnimation) {
+          if (newTime < 0) {
+            viewerState.setCurrentAnimationTime(0);
+            setCurrentTimeDisplay("00:00.00");
+          } else if (newTime > currentAnimation.duration) {
+            viewerState.setCurrentAnimationTime(currentAnimation.duration);
+            setCurrentTimeDisplay(formatTime(currentAnimation.duration));
+          } else {
+            viewerState.setCurrentAnimationTime(newTime);
+            setCurrentTimeDisplay(formatTime(newTime));
+          }
+        }
+      } else {
+        setCurrentTimeDisplay(formatTime(viewerState.currentAnimationTime));
       }
     };
 
-    const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-      curState.setCurrentFrame(event.target.value === '' ? 0 : Number(event.target.value));
+    const handleSliderChange = (event: Event, newValue: number | number[]) => {
+      if (viewerState.currentAnimationIndex === -1) return;
+
+      const percentage = newValue as number;
+      const currentAnimation = viewerState.animations[viewerState.currentAnimationIndex];
+      if (currentAnimation) {
+        const newTime = (percentage / 100) * currentAnimation.duration;
+        viewerState.setCurrentAnimationTime(newTime);
+      }
     };
 
-    const handleSliderChange = (event: Event, newValue: number | number[]) => {
-      curState.setCurrentFrame(newValue as number)
+
+    const handleInputKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Enter') {
+        (event.target as HTMLInputElement).blur();
+      }
+    };
+
+
+    // Calculate current percentage for slider
+    const getCurrentPercentage = (): number => {
+      if (viewerState.currentAnimationIndex === -1 || totalDuration === 0) return 0;
+      return (viewerState.currentAnimationTime / totalDuration) * 100;
+    };
+
+    // Format value for slider tooltip
+    const valueLabelFormat = (value: number): string => {
+      if (viewerState.currentAnimationIndex === -1 || totalDuration === 0) return "00:00.00";
+      const time = (value / 100) * totalDuration;
+      return formatTime(time);
     };
 
     useEffect(() => {
-      if (curState.viewerState.animations.length > 0 && curState.viewerState.currentAnimationIndex !== -1) 
+      if (curState.viewerState.animations.length > 0 && curState.viewerState.currentAnimationIndex !== -1)
       {
         setSelectedAnim(curState.viewerState.animations[curState.viewerState.currentAnimationIndex].name)
         handleAnimationChange(curState.viewerState.animations[curState.viewerState.currentAnimationIndex].name, false)
@@ -103,13 +194,13 @@ const BottomBar = React.forwardRef(function CustomContent(
       else if (curState.viewerState.currentAnimationIndex === -1){
         setSelectedAnim("")
       }
-    }, [curState.viewerState.animations, curState.viewerState.currentAnimationIndex, 
+    }, [curState.viewerState.animations, curState.viewerState.currentAnimationIndex,
         curState.viewerState.cameraDollies, curState.viewerState.currentDollyIndex,
             handleAnimationChange, selectedAnim, curState.viewerState.animationsNeedUpdate]);
 
     return (
       <Container ref={(ref as any) || bottomBarRef}>
-        <Grid container spacing={1} justifyContent="center">
+        <Grid container spacing={1} justifyContent="center" alignItems="center">
           <Grid item sx={{ mt: 1 }}>
             <CameraPanel uState={curState} />
           </Grid>
@@ -172,33 +263,44 @@ const BottomBar = React.forwardRef(function CustomContent(
           <Grid item sx={{ mt: 1 }}>
             <FormControl margin="dense" size="small" sx={{minWidth: minWidthSlider}}>
               <NonAnimatedSlider
-                defaultValue={50}
-                value={typeof curState.currentFrame === 'number' ? curState.currentFrame : 0}
-                aria-label="Default"
+                value={getCurrentPercentage()}
+                aria-label="Animation timeline"
                 valueLabelDisplay="auto"
+                valueLabelFormat={valueLabelFormat}
                 onChange={handleSliderChange}
                 disabled={curState.viewerState.animations.length < 1}/>
             </FormControl>
           </Grid>
-          {/// frame number
+          {/// Time display in mm:ss.dd format with total duration
           }
           <Grid item sx={{ mt: 1 }}>
             <FormControl margin="dense" size="small" variant="filled">
               <Input
                 sx={{maxWidth: maxWidthTime}}
                 size="small"
-                value={curState.currentFrame}
+                value={currentTimeDisplay}
                 onChange={handleInputChange}
-                onBlur={handleBlur}
+                onBlur={handleInputBlur}
+                onKeyPress={handleInputKeyPress}
                 inputProps={{
-                  step: 1,
-                  min: 0,
-                  max: 100,
-                  type: 'number',
-                  'aria-labelledby': 'input-slider'}}
+                  pattern: '^\\d{1,2}:\\d{2}\\.\\d{2}$',
+                  placeholder: 'mm:ss.dd',
+                  'aria-labelledby': 'time-input'}}
                 disabled={curState.viewerState.animations.length < 1}/>
             </FormControl>
           </Grid>
+          {/// Total duration display
+          curState.viewerState.animations.length > 0 && viewerState.currentAnimationIndex !== -1 && (
+            <Grid item sx={{ mt: 1 }}>
+              <span style={{
+                fontSize: '0.875rem',
+                color: 'text.secondary',
+                marginLeft: '4px'
+              }}>
+                / {totalDurationDisplay}
+              </span>
+            </Grid>
+          )}
           {curState.getGuiMode()?"":
           <Grid item sx={{ mt: 1 }}>
             <Tooltip title={t('bottomBar.autoRotate')}>

--- a/src/internationalization/i18n.js
+++ b/src/internationalization/i18n.js
@@ -118,7 +118,8 @@ i18next
                     },
                     snackbars: {
                         recording_video: "Recording Video...",
-                        processing_video: "Processing video..."
+                        processing_video: "Processing video...",
+                        no_animation_selected: "Select an animation to record."
                     },
                     floatingButton: {
                         model_info: "Model info",

--- a/src/state/ModelUIState.tsx
+++ b/src/state/ModelUIState.tsx
@@ -80,6 +80,7 @@ export class ModelUIState {
     guiHasAnimation: boolean = false
     guiAnimationStartTime: number = 0.0
     guiAnimationEndTime: number = 0.0
+    guiAnimationSpeed: number = 1.0
     constructor(
         currentModelPathState: string
     ) {
@@ -408,6 +409,7 @@ export class ModelUIState {
                 break;
             case "startAnimation":
                 this.SetAnimatingGUI(true);
+                this.guiAnimationSpeed = parsedMessage.Speed;
                 break;
             case "endAnimation":
                 this.SetAnimatingGUI(false);

--- a/src/state/ModelUIState.tsx
+++ b/src/state/ModelUIState.tsx
@@ -77,6 +77,9 @@ export class ModelUIState {
     isGUIAnimating: boolean = false
     processingSocketMessage: boolean = false
     fps: number = 60
+    guiHasAnimation: boolean = false
+    guiAnimationStartTime: number = 0.0
+    guiAnimationEndTime: number = 0.0
     constructor(
         currentModelPathState: string
     ) {
@@ -408,6 +411,16 @@ export class ModelUIState {
                 break;
             case "endAnimation":
                 this.SetAnimatingGUI(false);
+                break;
+            case "SetCurrentAnimation":
+                this.guiHasAnimation = true;
+                this.guiAnimationStartTime = parsedMessage.Start;
+                this.guiAnimationEndTime = parsedMessage.End;
+                break;
+            case "ClearCurrentAnimation":
+                this.guiHasAnimation = false;
+                this.guiAnimationStartTime = 0.0;
+                this.guiAnimationEndTime = 0.0;
                 break;
         }
     }

--- a/src/state/ModelUIState.tsx
+++ b/src/state/ModelUIState.tsx
@@ -118,6 +118,7 @@ export class ModelUIState {
             cameraLayersMask: observable,
             currentFrame: observable,
             setCurrentFrame: action,
+            incrementCurrentFrame: action,
             simulationTime: observable,
             setIsGuiMode: action,
             setIsModernBrowser: action,
@@ -219,6 +220,9 @@ export class ModelUIState {
     }
     setCurrentFrame(currentFrame: number) {
         this.currentFrame = currentFrame
+    }
+    incrementCurrentFrame() {
+        this.currentFrame += 1;
     }
     setModelInfo(curName: string, curDescription: string, curAuth: string) {
         this.modelInfo.model_name = curName

--- a/src/state/ModelUIState.tsx
+++ b/src/state/ModelUIState.tsx
@@ -431,6 +431,34 @@ export class ModelUIState {
             this.viewerState.setAnimating(false);
         }
     }
+
+    startGUIAnimationIfAvailable(requiredTimeStep: number) {
+        const json = JSON.stringify({
+        type: "Animation",
+        "OP": "Start",
+        "timestep": requiredTimeStep});
+        if (this.socket !== null)
+            this.socket!.send(json);
+    }
+    
+    stopGUIAnimation() {
+        const json = JSON.stringify({
+        type: "Animation",
+        "OP": "Stop"});
+        if (this.socket !== null)
+            this.socket!.send(json);
+    }
+    
+    setTimeGUIAnimation(time: number) {
+        const json = JSON.stringify({
+        type: "Animation",
+        "OP": "setTime",
+        "value": time
+        });
+        if (this.socket !== null)
+            this.socket!.send(json);
+    }
+    
     setFPS(fps: number) {
         this.fps = fps;
         var json = JSON.stringify({

--- a/src/state/ViewerState.tsx
+++ b/src/state/ViewerState.tsx
@@ -53,6 +53,8 @@ export class ViewerState {
     snapshotFormat: string
     recordedVideoName: string
     recordedVideoFormat: string
+    recordedVideoFPS: number
+    recordedVideoAspectRatio: string
     isRecordingVideo: boolean
     isProcessingVideo: boolean
     videoRecorderWidth: number | null
@@ -103,6 +105,7 @@ export class ViewerState {
     currentAnimationIndex: number
     animationsNeedUpdate: boolean
     animationChange: null | Object
+    currentAnimationTime: number
     // Environment holders
     environmentGroup: Group | null
     constructor(
@@ -133,6 +136,8 @@ export class ViewerState {
         this.snapshotFormat = snapshotFormat
         this.recordedVideoName = recordedVideoName
         this.recordedVideoFormat = recordedVideoFormat
+        this.recordedVideoFPS = 30
+        this.recordedVideoAspectRatio = "4:3"
         this.isRecordingVideo = isRecordingVideo
         this.isProcessingVideo = isProcessingVideo
         this.videoRecorderWidth = null
@@ -182,6 +187,7 @@ export class ViewerState {
         this.currentAnimationIndex = -1
         this.animationsNeedUpdate = false
         this.animationChange = null
+        this.currentAnimationTime = 0
         this.environmentGroup = null
         makeObservable(this, {
             currentModelPath: observable,
@@ -196,6 +202,8 @@ export class ViewerState {
             setSnapshotFormat: action,
             setRecordedVideoName: action,
             setRecordedVideoFormat: action,
+            setRecorderFPS: action,
+            setRecorderAspectRatio: action,
             setIsLoggedIn: action,
             setFloorHeight: action,
             setFloorRound: action,
@@ -203,6 +211,8 @@ export class ViewerState {
             snapshotFormat: observable,
             recordedVideoName: observable,
             recordedVideoFormat: observable,
+            recordedVideoFPS: observable,
+            recordedVideoAspectRatio: observable,
             isRecordingVideo: observable,
             videoRecorderWidth: observable,
             videoRecorderHeight: observable,
@@ -247,7 +257,9 @@ export class ViewerState {
             sceneVersion: observable,
             setSceneVersion: action,
             animationsNeedUpdate: observable,
-            setAnimationsNeedUpdate: action
+            setAnimationsNeedUpdate: action,
+            currentAnimationTime: observable,
+            setCurrentAnimationTime: action,
         })
     }
 
@@ -293,6 +305,12 @@ export class ViewerState {
     }
     setRecordedVideoFormat(newState: string) {
         this.recordedVideoFormat = newState
+    }
+    setRecorderFPS(newFPS: number) {
+        this.recordedVideoFPS = newFPS
+    }
+    setRecorderAspectRatio(newAspectRatio: string) {
+        this.recordedVideoAspectRatio = newAspectRatio
     }
     setVideoRecorderWidth(newWidth: number | null) {
       this.videoRecorderWidth = newWidth
@@ -614,6 +632,9 @@ export class ViewerState {
     }
     setAnimationsNeedUpdate(needsUpdate: boolean) {
         this.animationsNeedUpdate = needsUpdate;
+    }
+    setCurrentAnimationTime(time: number) {
+        this.currentAnimationTime = time;
     }
 }
 

--- a/src/state/ViewerState.tsx
+++ b/src/state/ViewerState.tsx
@@ -22,7 +22,7 @@ interface CamData {
 export class CameraDolly {
     name: string
     desc: string | null
-    cameraFrames: CameraFrame[] 
+    cameraFrames: CameraFrame[]
     constructor(name:string| "", desc:string|null=null){
         this.name = name
         this.desc = desc
@@ -57,8 +57,7 @@ export class ViewerState {
     recordedVideoAspectRatio: string
     isRecordingVideo: boolean
     isProcessingVideo: boolean
-    videoRecorderWidth: number | null
-    videoRecorderHeight: number | null
+    videoRecorderBaseDimension: number
     videoRecorderPreserveAspectRatio: boolean
     user_uuid: string
     // user preferences
@@ -137,11 +136,10 @@ export class ViewerState {
         this.recordedVideoName = recordedVideoName
         this.recordedVideoFormat = recordedVideoFormat
         this.recordedVideoFPS = 30
-        this.recordedVideoAspectRatio = "4:3"
+        this.recordedVideoAspectRatio = "16:9"
         this.isRecordingVideo = isRecordingVideo
         this.isProcessingVideo = isProcessingVideo
-        this.videoRecorderWidth = null
-        this.videoRecorderHeight = null
+        this.videoRecorderBaseDimension = 720
 
         this.videoRecorderPreserveAspectRatio = true
         this.user_uuid = ''
@@ -214,8 +212,8 @@ export class ViewerState {
             recordedVideoFPS: observable,
             recordedVideoAspectRatio: observable,
             isRecordingVideo: observable,
-            videoRecorderWidth: observable,
-            videoRecorderHeight: observable,
+            videoRecorderBaseDimension: observable,
+            setVideoRecorderBaseDimension: action,
             videoRecorderPreserveAspectRatio: observable,
             userPreferencesJsonPath: observable,
             userPreferences: observable,
@@ -312,11 +310,8 @@ export class ViewerState {
     setRecorderAspectRatio(newAspectRatio: string) {
         this.recordedVideoAspectRatio = newAspectRatio
     }
-    setVideoRecorderWidth(newWidth: number | null) {
-      this.videoRecorderWidth = newWidth
-    }
-    setVideoRecorderHeight(newHeight: number | null) {
-      this.videoRecorderHeight = newHeight
+    setVideoRecorderBaseDimension(dimension: number) {
+      this.videoRecorderBaseDimension = dimension
     }
     setVideoRecorderPreserveAspectRatio(newAspectRatio: boolean) {
       this.videoRecorderPreserveAspectRatio = newAspectRatio
@@ -350,7 +345,7 @@ export class ViewerState {
     }
     setSkyTextureIndex(newIndex: number) {
         this.skyTextureIndex = newIndex
-        if (newIndex === -1) 
+        if (newIndex === -1)
             this.skyVisible = false
         else
             this.skyVisible = true
@@ -444,12 +439,12 @@ export class ViewerState {
             console.error("Error loading user preferences:", error);
         }
     }
-    addCamera(camera: PerspectiveCamera, target: Vector3, 
-                suggestedName: string | undefined, 
-                setCurrent: boolean | undefined = true, 
+    addCamera(camera: PerspectiveCamera, target: Vector3,
+                suggestedName: string | undefined,
+                setCurrent: boolean | undefined = true,
                 preserveUuid: boolean = false) {
         const camClone = camera.clone()
-        if (suggestedName === undefined) 
+        if (suggestedName === undefined)
             camClone.name = "Camera_"+this.cameras.length
         else
             camClone.name = suggestedName;
@@ -491,11 +486,11 @@ export class ViewerState {
             this.cameras.splice(idx, 1);
             this.targets.splice(idx,1);
             // Fix current if needed
-            if (idx > this.cameras.length-1) 
+            if (idx > this.cameras.length-1)
                 this.setCurrentCameraIndex(this.cameras.length-1)
         }
         this.setSceneVersion(this.sceneVersion +1);
-    }    
+    }
     deleteCurrentDolly() {
         const idx = this.currentDollyIndex;
         const dolly = this.cameraDollies[idx];
@@ -503,7 +498,7 @@ export class ViewerState {
             // remove from cached arrays
             this.cameraDollies.splice(idx, 1);
            // Fix current if needed
-            if (idx > this.cameraDollies.length-1) 
+            if (idx > this.cameraDollies.length-1)
                 this.setCurrentDollyIndex(this.cameraDollies.length-1)
         }
         this.animations.splice(idx, 1);
@@ -598,11 +593,11 @@ export class ViewerState {
         readDollies.forEach(dolly => {
             this.addCameraDolly(dolly);
         });
-    } 
+    }
     loadCamerasFromJson(json: any) {
         // Load camerasJson from a file or database
         const readCameras: PerspectiveCamera[] = []
-        const camerasJson: any[] = json.cameras; 
+        const camerasJson: any[] = json.cameras;
         camerasJson.forEach(camData => {
             const camera = new PerspectiveCamera();
             camera.name = camData.object.name;

--- a/src/state/ViewerState.tsx
+++ b/src/state/ViewerState.tsx
@@ -55,6 +55,9 @@ export class ViewerState {
     recordedVideoFormat: string
     isRecordingVideo: boolean
     isProcessingVideo: boolean
+    videoRecorderWidth: number | null
+    videoRecorderHeight: number | null
+    videoRecorderPreserveAspectRatio: boolean
     user_uuid: string
     // user preferences
     userPreferencesJsonPath: string = ''
@@ -114,7 +117,7 @@ export class ViewerState {
         recordedVideoName: string,
         recordedVideoFormat: string,
         isRecordingVideo: boolean,
-        isProcessingVideo: boolean
+        isProcessingVideo: boolean,
     ) {
         this.userPreferences = observable({
             skyTexturePath: '',
@@ -132,6 +135,10 @@ export class ViewerState {
         this.recordedVideoFormat = recordedVideoFormat
         this.isRecordingVideo = isRecordingVideo
         this.isProcessingVideo = isProcessingVideo
+        this.videoRecorderWidth = null
+        this.videoRecorderHeight = null
+
+        this.videoRecorderPreserveAspectRatio = true
         this.user_uuid = ''
         this.backgroundColor = new Color(0.7, 0.7, 0.7)
         this.backgroundImage = null
@@ -197,6 +204,9 @@ export class ViewerState {
             recordedVideoName: observable,
             recordedVideoFormat: observable,
             isRecordingVideo: observable,
+            videoRecorderWidth: observable,
+            videoRecorderHeight: observable,
+            videoRecorderPreserveAspectRatio: observable,
             userPreferencesJsonPath: observable,
             userPreferences: observable,
             setUserPreferencesJsonPath: action,
@@ -283,6 +293,15 @@ export class ViewerState {
     }
     setRecordedVideoFormat(newState: string) {
         this.recordedVideoFormat = newState
+    }
+    setVideoRecorderWidth(newWidth: number | null) {
+      this.videoRecorderWidth = newWidth
+    }
+    setVideoRecorderHeight(newHeight: number | null) {
+      this.videoRecorderHeight = newHeight
+    }
+    setVideoRecorderPreserveAspectRatio(newAspectRatio: boolean) {
+      this.videoRecorderPreserveAspectRatio = newAspectRatio
     }
     setIsProcessingVideo(newState: boolean) {
         this.isProcessingVideo = newState


### PR DESCRIPTION
Hi @aymanhab, I am doing the recording of mp4 and mov videos in an offscreen canvas to control resolution and quality (to allow 4k). This is still a work in progress with not frontend to modify settings yet, but its working by changing them manually in the code.

I am trying to follow how you did it for screenshots, allowing to select default size (as seen in screen) or set custom.

I have a few topics for discussion here:
 - If screen aspect ratio is not preserved, the image can be highly distorted (this happens in screenshots too). Should we allow only custom resolution with fixed aspect ratio?
 - Related to this, I noticed allowing custom resolutions as numbers can be confusing to some users. Maybe it would be better to allow selecting resolutions in the same way as Youtube and many video editing software, which provides a selector with options (144p, 240p, 360p, 480p, 720p, 1080p_HD, 1440p_HD, 2160p_4K).
 - Since rendering offscreen takes time, higher resolutions can ralentize the application, and thus, affect framerate. I was thinking that instead of clicking play when animation recording starts, we should directly update frames from the recorder, so the recorder controls the animation in a way we ensure a fixed framerate. Again, I think providing a list of framerates could be more user friendly (15fps, 24fps, 30fps, 60fps) than allowing arbitrary framerates.
