### PR TITLE
Show hide axes

### DIFF
--- a/src/components/Components/OpenSimControl.tsx
+++ b/src/components/Components/OpenSimControl.tsx
@@ -31,7 +31,7 @@ const OpenSimControl = forwardRef<OpenSimControlHandle, GroupProps>((props, ref)
    const viewerState = useModelContext().viewerState;
    const controlsRef = useRef<OrbitControlsImpl | null>(null)
    const lastPosition = useRef(new Vector3())
-   camera.layers.enable(2); // Enable layer 2 for OpenSim helpers like frames and arrows
+   camera.layers.enable(2); // Enable layer 2 for OpenSim helpers like Frames (these mess up bounding boxes and selection if on layer 1)
 
   useImperativeHandle(ref, () => ({
     addCamera: (cameraName: any, parent: Object3D | null) => {

--- a/src/components/Components/OpenSimControl.tsx
+++ b/src/components/Components/OpenSimControl.tsx
@@ -31,6 +31,7 @@ const OpenSimControl = forwardRef<OpenSimControlHandle, GroupProps>((props, ref)
    const viewerState = useModelContext().viewerState;
    const controlsRef = useRef<OrbitControlsImpl | null>(null)
    const lastPosition = useRef(new Vector3())
+   camera.layers.enable(2); // Enable layer 2 for OpenSim helpers like frames and arrows
 
   useImperativeHandle(ref, () => ({
     addCamera: (cameraName: any, parent: Object3D | null) => {

--- a/src/state/ModelUIState.tsx
+++ b/src/state/ModelUIState.tsx
@@ -103,7 +103,7 @@ export class ModelUIState {
         this.fitToBox = null
         this.debug = false
         this.simulationTime=0.0
-        this.viewerState = new ViewerState(currentModelPathState, '/builtin/featured-models.json', false, false, false, false, "opensim-viewer-snapshot", 'png', "opensim-viewer-video", 'webm', false, false);
+        this.viewerState = new ViewerState(currentModelPathState, '/builtin/featured-models.json', false, false, false, false, "opensim-viewer-snapshot", 'png', "opensim-viewer-video", 'mp4', false, false);
         makeObservable(this, {
             zooming: observable,
             showGlobalFrame: observable,

--- a/src/state/OpenSimLoader.js
+++ b/src/state/OpenSimLoader.js
@@ -702,7 +702,7 @@ parseObject( data, geometries, materials, textures, animations ) {
         // NOW OpenSim types
         case 'Frame':
            object = new AxesHelper(data.size);
-           object.layers.set(3)
+           object.layers.set(2)
            break;
         case 'Arrow':
             object = new ArrowHelper(data.dir, data.origin, 1.0, data.color);


### PR DESCRIPTION
Add axes on a separate layer and make the layer visible by the camera. This allows proper show/hide of axes without confusing the picking code. Would be good to know if/how layers are used elsewhere to avoid possible side effects