### PR TITLE
Removed jpeg compression. Increased pixel ratio, removed canvas resize.

### DIFF
--- a/src/components/Components/RecordingModal.tsx
+++ b/src/components/Components/RecordingModal.tsx
@@ -23,7 +23,6 @@ interface RecordingModalProps {
 
 // Define quality levels that will be used as base dimensions
 const qualityLevels = [
-  /*{ label: "720p HD", baseDimension: 720 },*/
   { label: "1080p HD", baseDimension: 1080 },
   { label: "1440p HD", baseDimension: 1440 },
   { label: "2160p 4K", baseDimension: 2160 },
@@ -35,7 +34,7 @@ const videoFormats = [
   { label: "JPEG (Zip)", value: "jpeg-zip"}
 ];
 
-const fpsValues = [/*24, */30, 60];
+const fpsValues = [30, 60];
 
 const aspectRatios = [
   { label: "4:3", value: "4:3", description: "standard" },
@@ -52,7 +51,7 @@ const RecordingModal: React.FC<RecordingModalProps> = ({ videoRecorderRef }) => 
   const viewerState = curState.viewerState;
 
   const [open, setOpen] = useState(false);
-  const [selectedQuality, setSelectedQuality] = useState("2160p 4K");
+  const [selectedQuality, setSelectedQuality] = useState("1080p HD");
   const [selectedFormat, setSelectedFormat] = useState("mp4");
   const [selectedFPS, setSelectedFPS] = useState(30);
   const [selectedAspectRatio, setSelectedAspectRatio] = useState("16:9");

--- a/src/components/Components/RecordingModal.tsx
+++ b/src/components/Components/RecordingModal.tsx
@@ -23,7 +23,7 @@ interface RecordingModalProps {
 
 // Define quality levels that will be used as base dimensions
 const qualityLevels = [
-  { label: "720p HD", baseDimension: 720 },
+  /*{ label: "720p HD", baseDimension: 720 },*/
   { label: "1080p HD", baseDimension: 1080 },
   { label: "1440p HD", baseDimension: 1440 },
   { label: "2160p 4K", baseDimension: 2160 },
@@ -35,7 +35,7 @@ const videoFormats = [
   { label: "JPEG (Zip)", value: "jpeg-zip"}
 ];
 
-const fpsValues = [24, 30, 60];
+const fpsValues = [/*24, */30, 60];
 
 const aspectRatios = [
   { label: "4:3", value: "4:3", description: "standard" },
@@ -52,7 +52,7 @@ const RecordingModal: React.FC<RecordingModalProps> = ({ videoRecorderRef }) => 
   const viewerState = curState.viewerState;
 
   const [open, setOpen] = useState(false);
-  const [selectedQuality, setSelectedQuality] = useState("720p HD");
+  const [selectedQuality, setSelectedQuality] = useState("2160p 4K");
   const [selectedFormat, setSelectedFormat] = useState("mp4");
   const [selectedFPS, setSelectedFPS] = useState(30);
   const [selectedAspectRatio, setSelectedAspectRatio] = useState("16:9");

--- a/src/components/Components/VideoRecorder.tsx
+++ b/src/components/Components/VideoRecorder.tsx
@@ -162,7 +162,7 @@ function VideoRecorder(props: VideoRecorderViewProps) {
 
     // Update renderer size
     gl.setSize(evenW, evenH, false);
-    gl.setPixelRatio(1); // Ensure crisp rendering at exact dimensions
+    gl.setPixelRatio(2); // Ensure crisp rendering at exact dimensions
 
     return { width: evenW, height: evenH };
   };
@@ -199,10 +199,10 @@ function VideoRecorder(props: VideoRecorderViewProps) {
     ctx.fillRect(0, 0, evenW, evenH);
 
     // Draw the WebGL canvas content
-    ctx.drawImage(glCanvas, 0, 0, evenW, evenH);
+    ctx.drawImage(glCanvas, 0, 0);
 
     // Encode as JPEG (no alpha)
-    return compositeCanvas.toDataURL('image/jpeg', 0.92);
+    return compositeCanvas.toDataURL('image/jpeg');
   };
 
   const encodeFramesToVideo = async (ext: 'mp4' | 'mov' | 'webm') => {
@@ -240,7 +240,6 @@ function VideoRecorder(props: VideoRecorderViewProps) {
       '-framerate', `${fps}`,
       '-i', 'input%03d.jpg',
       '-r', `${fps}`,
-      '-vf', `scale=${evenW}:${evenH}:flags=lanczos:force_original_aspect_ratio=disable`
     ];
 
     if (ext === 'webm') {

--- a/src/state/ViewerState.tsx
+++ b/src/state/ViewerState.tsx
@@ -137,11 +137,12 @@ export class ViewerState {
         this.snapshotFormat = snapshotFormat
         this.recordedVideoName = recordedVideoName
         this.recordedVideoFormat = recordedVideoFormat
-        this.recordedVideoFPS = 30
-        this.recordedVideoAspectRatio = "16:9"
         this.isRecordingVideo = isRecordingVideo
         this.isProcessingVideo = isProcessingVideo
-        this.videoRecorderBaseDimension = 1440
+        // Default values here is not used as selected in interface before start recording.
+        this.recordedVideoFPS = 30
+        this.recordedVideoAspectRatio = "16:9"
+        this.videoRecorderBaseDimension = 1080
 
         this.videoRecorderPreserveAspectRatio = true
         this.user_uuid = ''

--- a/src/state/ViewerState.tsx
+++ b/src/state/ViewerState.tsx
@@ -141,7 +141,7 @@ export class ViewerState {
         this.recordedVideoAspectRatio = "16:9"
         this.isRecordingVideo = isRecordingVideo
         this.isProcessingVideo = isProcessingVideo
-        this.videoRecorderBaseDimension = 720
+        this.videoRecorderBaseDimension = 1440
 
         this.videoRecorderPreserveAspectRatio = true
         this.user_uuid = ''


### PR DESCRIPTION
This should take care of the issue related to low quality videos even at high resolutions.

I removed some resize steps in both ffmpeg and when saving canvas images, increased pixel ratio, and removed jpeg compression.

Though the quality increased, I have not noticed effects in performance, it does not look much slower.

If we want more quality, we could change ffmpeg parameters:

```python
args.push('-c:v', 'libx264', '-pix_fmt', 'yuv420p', '-preset', 'fast', '-crf', '17');
```

In this case, decrease `-crf` and change `-preset` to `slow` instead of fast, but this will affect performance.