### PR TITLE
Handle SetAnimationSpeed on viewer side

### DIFF
--- a/src/state/ModelUIState.tsx
+++ b/src/state/ModelUIState.tsx
@@ -493,6 +493,9 @@ export class ModelUIState {
                 this.viewerState.animationChange = {index:0, operation:"start"};
                 this.viewerState.setAnimationsNeedUpdate(true)
                 break;
+            case "SetAnimationSpeed":
+                this.guiAnimationSpeed = parsedMessage.speed;
+                break;
             case "HeartBeat":
                 console.log("Hearbeat received")
                 this.sendModelOffsets();


### PR DESCRIPTION
When speed spinner is changed, send a message to the viewer to update value in viewerState and this is used immediately to update mixers so takes effect immediately.