### PR TITLE
Fixing videos fallback

### DIFF
--- a/src/components/Components/RecordingModal.tsx
+++ b/src/components/Components/RecordingModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   Button,
   Dialog,
@@ -36,6 +36,7 @@ const videoFormats = [
 ];
 
 const fpsValues = [30, 60];
+const fpsValuesGif = [25, 50];
 
 const aspectRatios = [
   { label: "4:3", value: "4:3", description: "standard" },
@@ -59,6 +60,18 @@ const RecordingModal: React.FC<RecordingModalProps> = ({ videoRecorderRef }) => 
 
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
+
+  const getFpsOptions = () => {
+    return selectedFormat === 'gif' ? fpsValuesGif : fpsValues;
+  };
+
+  useEffect(() => {
+    const validFpsOptions = getFpsOptions();
+    if (!validFpsOptions.includes(selectedFPS)) {
+      setSelectedFPS(validFpsOptions[0]);
+      viewerState.setRecorderFPS(validFpsOptions[0]);
+    }
+  }, [selectedFormat]);
 
   const handleRecord = () => {
     setOpen(false);
@@ -174,7 +187,7 @@ const RecordingModal: React.FC<RecordingModalProps> = ({ videoRecorderRef }) => 
               label="FPS"
               onChange={(e) => handleFPSChange(Number(e.target.value))}
             >
-              {fpsValues.map((fps) => (
+              {getFpsOptions().map((fps) => (
                 <MenuItem key={fps} value={fps}>
                   {fps}
                 </MenuItem>

--- a/src/components/Components/VideoRecorder.tsx
+++ b/src/components/Components/VideoRecorder.tsx
@@ -547,6 +547,16 @@ function VideoRecorder(props: VideoRecorderViewProps) {
         return;
       }
 
+      // Cleanup ffmpeg directory
+      try {
+        const files = await ffmpegRef.current.listDir('/');
+        for (const file of files) {
+          if (file.name.startsWith('input') || file.name.startsWith('gif')) {
+            await ffmpegRef.current.deleteFile(file.name);
+          }
+        }
+      } catch {}
+
       const animation = viewerState.animations[current[0]];
       animationDurationRef.current = animation.duration;
 

--- a/src/components/Components/VideoRecorder.tsx
+++ b/src/components/Components/VideoRecorder.tsx
@@ -426,7 +426,12 @@ function VideoRecorder(props: VideoRecorderViewProps) {
         await ffmpeg.writeFile(`gif${String(i).padStart(3, '0')}.jpg`, await fetchFile(blob));
       }
 
-      const fps = viewerState.recordedVideoFPS || 30;
+      let fps = viewerState.recordedVideoFPS || 30;
+
+      if (fps == 30)
+        fps = 25
+      if (fps == 60)
+        fps = 50
 
       await ffmpeg.exec(['-framerate', `${fps}`, '-i', 'gif%03d.jpg', '-vf', 'palettegen', 'palette.png']);
       await ffmpeg.exec([
@@ -580,6 +585,13 @@ function VideoRecorder(props: VideoRecorderViewProps) {
       let effectiveDuration = animationDurationRef.current;
       let effectiveFps = fps;
 
+      if (viewerState.recordedVideoFormat == "gif") {
+        if (effectiveFps == 30)
+          effectiveFps = 25
+        if (effectiveFps == 60)
+          effectiveFps = 50
+      }
+
       if (animationSpeed > 0) {
         // Adjust duration based on speed
         effectiveDuration = animationDurationRef.current / animationSpeed;
@@ -595,7 +607,7 @@ function VideoRecorder(props: VideoRecorderViewProps) {
       }
 
       // Calculate total frames based on effective duration
-      const totalFrames = Math.ceil(effectiveDuration * fps);
+      const totalFrames = Math.ceil(effectiveDuration * effectiveFps);
 
       // Validate total frames
       if (totalFrames > 5000) {
@@ -626,7 +638,7 @@ function VideoRecorder(props: VideoRecorderViewProps) {
       const loop = async () => {
         while (isRecordingRef.current && frameCount < totalFrames && captureErrors < MAX_ERRORS) {
           // Calculate animation time based on speed
-          const animationTime = (frameCount / fps) * animationSpeed;
+          const animationTime = (frameCount / effectiveFps) * animationSpeed;
 
           // Clamp to animation duration to avoid going beyond
           const clampedTime = Math.min(animationTime, animationDurationRef.current);


### PR DESCRIPTION
This should solve:

- If you record a video while loop a motion, the recorded motion has doubled speed.
- When recording videos at 30fps, the video playback includes the full motion at the expected playback speed. However, after that, additional playback of the motion at slower than real-time is included.
- Playback of recorded GIFs is slower than realtime.