### PR TITLE
Fixing trimming when range starts different from 0.

### DIFF
--- a/src/components/Components/RecordModeOverlay.tsx
+++ b/src/components/Components/RecordModeOverlay.tsx
@@ -219,7 +219,6 @@ const RecordModeOverlay: React.FC<RecordModeOverlayProps> = ({
       </OverlayContainer>
 
       <RecordingModal
-        videoRecorderRef={videoRecorderRef}
         open={isModalOpen}
         onClose={handleModalClose}
       />

--- a/src/components/Components/RecordingModal.tsx
+++ b/src/components/Components/RecordingModal.tsx
@@ -63,6 +63,8 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
   const [selectedFPS, setSelectedFPS] = useState(30);
   const [selectedAspectRatio, setSelectedAspectRatio] = useState("16:9");
 
+  const [videoName, setVideoName] = useState("");
+
   const [trimMotion, setTrimMotion] = useState(false);
   const [loopsToRecord, setLoopsToRecord] = useState<string>("1");
   const [startTime, setStartTime] = useState<string>("0.0");
@@ -94,6 +96,57 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
   useEffect(() => {
     if (!open) return;
 
+    // Quality
+    const baseDimension = viewerState.videoRecorderBaseDimension;
+    const matchingQuality = qualityLevels.find(
+      (q) => q.baseDimension === baseDimension
+    );
+
+    if (matchingQuality) {
+      setSelectedQuality(matchingQuality.label);
+    } else {
+      setSelectedQuality("1080p HD");
+    }
+
+    // Format
+    const format = viewerState.recordedVideoFormat || "mp4";
+    setSelectedFormat(format);
+
+    // FPS
+    const fps = viewerState.recordedVideoFPS || 30;
+    setSelectedFPS(fps);
+
+    // Aspect ratio
+    setSelectedAspectRatio(
+      viewerState.recordedVideoAspectRatio || "16:9"
+    );
+
+    // Trimming
+    setTrimMotion(viewerState.isTrimmingMotion || false);
+
+    // Loops
+    setLoopsToRecord(
+      String(viewerState.videoRecorderNumLoops || 1)
+    );
+
+    // Video name
+    const currentName = viewerState.recordedVideoName || "";
+
+    const knownExtensions = videoFormats.map(
+      (format) => `.${format.value}`
+    );
+
+    const existingExtension = knownExtensions.find((ext) =>
+      currentName.toLowerCase().endsWith(ext.toLowerCase())
+    );
+
+    const nameWithoutExtension = existingExtension
+      ? currentName.slice(0, -existingExtension.length)
+      : currentName;
+
+    setVideoName(nameWithoutExtension);
+
+    // Animation time information
     const { duration, startOffset } = getCurrentAnimationInfo();
 
     setMaxTime(duration);
@@ -116,9 +169,7 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
     setEndTime(endTime.toFixed(1));
     setTimeRange([startTime, endTime]);
 
-    viewerState.setVideoRecorderStartTime(startTime);
-    viewerState.setVideoRecorderEndTime(endTime);
-  }, [open, viewerState.currentAnimationIndices, viewerState.animations]);
+  }, [open]);
 
   const getFpsOptions = () => {
     return selectedFormat === "gif" ? fpsValuesGif : fpsValues;
@@ -168,107 +219,62 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
 
   useEffect(() => {
     const validFpsOptions = getFpsOptions();
+
     if (!validFpsOptions.includes(selectedFPS)) {
       setSelectedFPS(validFpsOptions[0]);
-      viewerState.setRecorderFPS(validFpsOptions[0]);
     }
   }, [selectedFormat]);
 
- const getVideoNameWithoutExtension = () => {
-    const currentName = viewerState.recordedVideoName || "";
-    const extension = `.${selectedFormat}`;
-
-    if (currentName.toLowerCase().endsWith(extension.toLowerCase())) {
-      return currentName.slice(0, -extension.length);
-    }
-
-    const knownExtensions = videoFormats.map((format) => `.${format.value}`);
-    const existingExtension = knownExtensions.find((ext) =>
-      currentName.toLowerCase().endsWith(ext.toLowerCase())
-    );
-
-    if (existingExtension) {
-      return currentName.slice(0, -existingExtension.length);
-    }
-
-    return currentName;
+  const getVideoNameWithoutExtension = () => {
+    return videoName;
   };
 
-  const handleVideoNameChange = (event:any) => {
-    const nameWithoutExtension = event.target.value;
-    viewerState.setRecordedVideoName(`${nameWithoutExtension}.${selectedFormat}`)
+  const handleVideoNameChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setVideoName(event.target.value);
   };
 
   const handleFormatChange = (value: string) => {
-    const currentName = viewerState.recordedVideoName || "";
-    const knownExtensions = videoFormats.map((format) => `.${format.value}`);
-    const existingExtension = knownExtensions.find((ext) =>
-      currentName.toLowerCase().endsWith(ext.toLowerCase())
-    );
-
-    const nameWithoutExtension = existingExtension
-      ? currentName.slice(0, -existingExtension.length)
-      : currentName;
-
     setSelectedFormat(value);
-    viewerState.setRecordedVideoFormat(value);
-    viewerState.setRecordedVideoName(`${nameWithoutExtension}.${value}`);
   };
 
   const handleFPSChange = (value: number) => {
     setSelectedFPS(value);
-    viewerState.setRecorderFPS(value);
   };
 
   const handleAspectRatioChange = (value: string) => {
     setSelectedAspectRatio(value);
-    viewerState.setRecorderAspectRatio(value);
   };
 
   const handleQualityChange = (value: string) => {
     setSelectedQuality(value);
-    const chosen = qualityLevels.find((q) => q.label === value);
-    if (chosen) {
-      // Only set the base dimension, let the aspect ratio calculation determine final dimensions
-      viewerState.setVideoRecorderBaseDimension(chosen.baseDimension);
-    }
   };
 
   const handleIsTrimmingMotion = (value: boolean) => {
-    setTrimMotion(value)
-    viewerState.setIsTrimmingMotion(value)
+    setTrimMotion(value);
 
-    // If trimming is disabled, reset to full animation
+    // If trimming is disabled, reset local times to full animation
     if (!value) {
       const { duration, startOffset } = getCurrentAnimationInfo();
-      const roundedStart = startOffset;
-      const roundedEnd = duration;
 
-      setStartTime(roundedStart.toFixed(1));
-      setEndTime(roundedEnd.toFixed(1));
-      setTimeRange([roundedStart, roundedEnd]);
-
-      viewerState.setVideoRecorderStartTime(roundedStart);
-      viewerState.setVideoRecorderEndTime(roundedEnd);
+      setStartTime(startOffset.toFixed(1));
+      setEndTime(duration.toFixed(1));
+      setTimeRange([startOffset, duration]);
     }
   };
 
   const handleLoopsChange = (value: string) => {
     if (value === "" || validateInteger(value)) {
-        setLoopsToRecord(value);
-
-        // Only update viewer state if we have a valid number
-        if (value !== "") {
-            const numValue = parseInt(value, 10);
-            // Clamp the value for the viewer state
-            const clampedValue = Math.min(Math.max(1, numValue), maxLoops);
-            viewerState.setVideoRecorderNumLoops(clampedValue);
-        }
+      setLoopsToRecord(value);
     }
   };
 
   // Handle slider change with two handlers
-  const handleTimeRangeChange = (event: Event, newValue: number | number[]) => {
+  const handleTimeRangeChange = (
+    event: Event,
+    newValue: number | number[]
+  ) => {
     const range = newValue as number[];
 
     const start = range[0];
@@ -277,9 +283,6 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
     setTimeRange([start, end]);
     setStartTime(start.toFixed(1));
     setEndTime(end.toFixed(1));
-
-    viewerState.setVideoRecorderStartTime(start);
-    viewerState.setVideoRecorderEndTime(end);
   };
 
   const handleStartTimeChange = (value: string) => {
@@ -292,11 +295,9 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
       numValue >= animationStartOffset &&
       numValue < timeRange[1]
     ) {
-      const roundedValue = numValue;
-      setTimeRange([roundedValue, timeRange[1]]);
-      viewerState.setVideoRecorderStartTime(roundedValue);
+      setTimeRange([numValue, timeRange[1]]);
     }
-  }
+  };
 
   const handleEndTimeChange = (value: string) => {
     setEndTime(value);
@@ -308,11 +309,61 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
       numValue > timeRange[0] &&
       numValue <= maxTime
     ) {
-      const roundedValue = numValue;
-      setTimeRange([timeRange[0], roundedValue]);
-      viewerState.setVideoRecorderEndTime(roundedValue);
+      setTimeRange([timeRange[0], numValue]);
     }
-  }
+  };
+
+  const handleSave = () => {
+    // Video name
+    viewerState.setRecordedVideoName(
+      `${videoName}.${selectedFormat}`
+    );
+
+    // Format
+    viewerState.setRecordedVideoFormat(selectedFormat);
+
+    // FPS
+    viewerState.setRecorderFPS(selectedFPS);
+
+    // Aspect ratio
+    viewerState.setRecorderAspectRatio(selectedAspectRatio);
+
+    // Quality
+    const chosenQuality = qualityLevels.find(
+      (q) => q.label === selectedQuality
+    );
+
+    if (chosenQuality) {
+      viewerState.setVideoRecorderBaseDimension(
+        chosenQuality.baseDimension
+      );
+    }
+
+    // Trimming
+    viewerState.setIsTrimmingMotion(trimMotion);
+
+    // Loops
+    if (loopsToRecord !== "") {
+      const numLoops = parseInt(loopsToRecord, 10);
+      const clampedLoops = Math.min(
+        Math.max(1, numLoops),
+        maxLoops
+      );
+
+      viewerState.setVideoRecorderNumLoops(clampedLoops);
+    }
+
+    // Times
+    const start = parseFloat(startTime);
+    const end = parseFloat(endTime);
+
+    if (!isNaN(start) && !isNaN(end)) {
+      viewerState.setVideoRecorderStartTime(start);
+      viewerState.setVideoRecorderEndTime(end);
+    }
+
+    onClose();
+  };
 
  const validateTimeFormat = (time: string): boolean => {
     // Allow empty string or valid number format
@@ -543,7 +594,16 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
       </DialogContent>
 
       <DialogActions>
-        <Button onClick={onClose}>Submit</Button>
+        <Button onClick={onClose}>
+          Cancel
+        </Button>
+
+        <Button
+          onClick={handleSave}
+          variant="contained"
+        >
+          Save
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/src/components/Components/RecordingModal.tsx
+++ b/src/components/Components/RecordingModal.tsx
@@ -13,6 +13,7 @@ import {
   FormControlLabel,
   TextField,
   Slider,
+  InputAdornment,
 } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { useModelContext } from "../../state/ModelUIStateContext";
@@ -33,7 +34,7 @@ const qualityLevels = [
 const videoFormats = [
   { label: "MP4", value: "mp4" },
   { label: "MOV", value: "mov" },
-  { label: "JPEG (Zip)", value: "jpeg-zip" },
+  { label: "JPEG (Zip)", value: "zip" },
   { label: "GIF", value: "gif" },
 ];
 
@@ -173,13 +174,45 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
     }
   }, [selectedFormat]);
 
+ const getVideoNameWithoutExtension = () => {
+    const currentName = viewerState.recordedVideoName || "";
+    const extension = `.${selectedFormat}`;
+
+    if (currentName.toLowerCase().endsWith(extension.toLowerCase())) {
+      return currentName.slice(0, -extension.length);
+    }
+
+    const knownExtensions = videoFormats.map((format) => `.${format.value}`);
+    const existingExtension = knownExtensions.find((ext) =>
+      currentName.toLowerCase().endsWith(ext.toLowerCase())
+    );
+
+    if (existingExtension) {
+      return currentName.slice(0, -existingExtension.length);
+    }
+
+    return currentName;
+  };
+
   const handleVideoNameChange = (event:any) => {
-    viewerState.setRecordedVideoName(event.target.value)
+    const nameWithoutExtension = event.target.value;
+    viewerState.setRecordedVideoName(`${nameWithoutExtension}.${selectedFormat}`)
   };
 
   const handleFormatChange = (value: string) => {
+    const currentName = viewerState.recordedVideoName || "";
+    const knownExtensions = videoFormats.map((format) => `.${format.value}`);
+    const existingExtension = knownExtensions.find((ext) =>
+      currentName.toLowerCase().endsWith(ext.toLowerCase())
+    );
+
+    const nameWithoutExtension = existingExtension
+      ? currentName.slice(0, -existingExtension.length)
+      : currentName;
+
     setSelectedFormat(value);
     viewerState.setRecordedVideoFormat(value);
+    viewerState.setRecordedVideoName(`${nameWithoutExtension}.${value}`);
   };
 
   const handleFPSChange = (value: number) => {
@@ -325,15 +358,22 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
 
       <DialogContent sx={{ minWidth: 300 }}>
 
-        {/* Video Name */}
-        <FormControl fullWidth margin="dense">
-           <TextField
-            size="small"
-            label={t('recordView.video_name_label')}
-            value={viewerState.recordedVideoName}
-            onChange={handleVideoNameChange}
+         {/* Video Name */}
+         <FormControl fullWidth margin="dense">
+            <TextField
+             size="small"
+             label={t('recordView.video_name_label')}
+             value={getVideoNameWithoutExtension()}
+             onChange={handleVideoNameChange}
+             InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    .{selectedFormat}
+                  </InputAdornment>
+                ),
+              }}
           />
-        </FormControl>
+         </FormControl>
 
         {/* Aspect Ratio */}
         {curState.showAspectRatioFunctionality && (

--- a/src/components/Components/RecordingModal.tsx
+++ b/src/components/Components/RecordingModal.tsx
@@ -19,7 +19,6 @@ import { useModelContext } from "../../state/ModelUIStateContext";
 import { observer } from "mobx-react";
 
 interface RecordingModalProps {
-  videoRecorderRef: React.MutableRefObject<any>;
   open: boolean;
   onClose: () => void;
 }
@@ -51,7 +50,6 @@ const aspectRatios = [
 ];
 
 const RecordingModal: React.FC<RecordingModalProps> = ({
-  videoRecorderRef,
   open,
   onClose,
 }) => {
@@ -68,56 +66,58 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
   const [loopsToRecord, setLoopsToRecord] = useState<string>("1");
   const [startTime, setStartTime] = useState<string>("0.0");
   const [endTime, setEndTime] = useState<string>("1.0");
-  const [maxLoops] = useState<number>(10); // Limited to 10 to avoid long waiting times.
+  const maxLoops = 10; // Limited to 10 to avoid long waiting times.
 
   // Slider range state
   const [timeRange, setTimeRange] = useState<number[]>([0, 1]);
   const [maxTime, setMaxTime] = useState<number>(10);
+  const [animationStartOffset, setAnimationStartOffset] = useState<number>(0);
 
-  // Get the current animation duration
-  const getCurrentAnimationDuration = (): number => {
+  // Get the current animation absolute end time and start offset
+  const getCurrentAnimationInfo = (): { duration: number; startOffset: number } => {
     const currentIndex = viewerState.currentAnimationIndices[0];
     if (currentIndex !== undefined && currentIndex >= 0 && currentIndex < viewerState.animations.length) {
       const animation = viewerState.animations[currentIndex];
-      // Subtract the start time offset to get the effective duration
-      const startTimeOffset = viewerState.animationStartTimes[currentIndex] || 0;
-      return Math.max(0, animation.duration - startTimeOffset);
+      const startOffset = viewerState.animationStartTimes[currentIndex] ?? 0;
+      // animation.duration is the absolute end time of the animation.
+      // startOffset is the absolute start time of the animation.
+      return {
+        duration: animation.duration,
+        startOffset
+      };
     }
-    return 10; // Default fallback
+    return { duration: 10, startOffset: 0 };
   };
 
   // Update max time and slider range when animation changes or modal opens
   useEffect(() => {
-    if (open) {
-      const duration = getCurrentAnimationDuration();
-      setMaxTime(Math.max(1, duration)); // Ensure at least 1 second
+    if (!open) return;
 
-      // Update end time to match animation duration
-      const newEndTime = Math.max(1, duration);
-      setEndTime(String(newEndTime));
-      viewerState.setVideoRecorderEndTime(newEndTime);
+    const { duration, startOffset } = getCurrentAnimationInfo();
 
-      // Update slider range
-      setTimeRange([0, newEndTime]);
-    }
+    setMaxTime(duration);
+    setAnimationStartOffset(startOffset);
+
+    const savedStartTime = viewerState.videoRecorderStartTime;
+    const savedEndTime = viewerState.videoRecorderEndTime;
+
+    const startTime =
+      savedStartTime >= startOffset && savedStartTime < duration
+        ? savedStartTime
+        : startOffset;
+
+    const endTime =
+      savedEndTime > startTime && savedEndTime <= duration
+        ? savedEndTime
+        : duration;
+
+    setStartTime(startTime.toFixed(1));
+    setEndTime(endTime.toFixed(1));
+    setTimeRange([startTime, endTime]);
+
+    viewerState.setVideoRecorderStartTime(startTime);
+    viewerState.setVideoRecorderEndTime(endTime);
   }, [open, viewerState.currentAnimationIndices, viewerState.animations]);
-
-  // Watch for animation changes while modal is open
-  useEffect(() => {
-    if (open) {
-      const duration = getCurrentAnimationDuration();
-      setMaxTime(Math.max(1, duration));
-
-      // Only update if the current end time exceeds the new duration
-      const currentEndTime = parseFloat(endTime);
-      if (currentEndTime > duration || isNaN(currentEndTime)) {
-        const newEndTime = Math.max(1, duration);
-        setEndTime(String(newEndTime));
-        viewerState.setVideoRecorderEndTime(newEndTime);
-        setTimeRange([timeRange[0], newEndTime]);
-      }
-    }
-  }, [viewerState.animations, viewerState.currentAnimationIndices]);
 
   const getFpsOptions = () => {
     return selectedFormat === "gif" ? fpsValuesGif : fpsValues;
@@ -162,20 +162,6 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
       if(viewerState.videoRecorderNumLoops) {
         setLoopsToRecord(String(viewerState.videoRecorderNumLoops))
       }
-
-      // Set start time
-      if(viewerState.videoRecorderStartTime) {
-        setStartTime(String(viewerState.videoRecorderStartTime))
-        // Initialize slider start value
-        setTimeRange(prev => [viewerState.videoRecorderStartTime, prev[1]]);
-      }
-
-      // Set end time
-      const duration = getCurrentAnimationDuration();
-      const currentEndTime = viewerState.videoRecorderEndTime || duration;
-      setEndTime(String(Math.min(currentEndTime, duration)));
-      setTimeRange(prev => [prev[0], Math.min(currentEndTime, duration)]);
-      setMaxTime(Math.max(1, duration));
     }
   }, [open, viewerState]);
 
@@ -197,8 +183,8 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
   };
 
   const handleFPSChange = (value: number) => {
-    setSelectedFPS(Number(value));
-    viewerState.setRecorderFPS(Number(value));
+    setSelectedFPS(value);
+    viewerState.setRecorderFPS(value);
   };
 
   const handleAspectRatioChange = (value: string) => {
@@ -218,6 +204,20 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
   const handleIsTrimmingMotion = (value: boolean) => {
     setTrimMotion(value)
     viewerState.setIsTrimmingMotion(value)
+
+    // If trimming is disabled, reset to full animation
+    if (!value) {
+      const { duration, startOffset } = getCurrentAnimationInfo();
+      const roundedStart = startOffset;
+      const roundedEnd = duration;
+
+      setStartTime(roundedStart.toFixed(1));
+      setEndTime(roundedEnd.toFixed(1));
+      setTimeRange([roundedStart, roundedEnd]);
+
+      viewerState.setVideoRecorderStartTime(roundedStart);
+      viewerState.setVideoRecorderEndTime(roundedEnd);
+    }
   };
 
   const handleLoopsChange = (value: string) => {
@@ -237,38 +237,47 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
   // Handle slider change with two handlers
   const handleTimeRangeChange = (event: Event, newValue: number | number[]) => {
     const range = newValue as number[];
-    setTimeRange(range);
 
-    // Update start time
-    const startValue = range[0];
-    setStartTime(String(startValue));
-    viewerState.setVideoRecorderStartTime(startValue);
+    const start = range[0];
+    const end = range[1];
 
-    // Update end time
-    const endValue = range[1];
-    setEndTime(String(endValue));
-    viewerState.setVideoRecorderEndTime(endValue);
+    setTimeRange([start, end]);
+    setStartTime(start.toFixed(1));
+    setEndTime(end.toFixed(1));
+
+    viewerState.setVideoRecorderStartTime(start);
+    viewerState.setVideoRecorderEndTime(end);
   };
 
   const handleStartTimeChange = (value: string) => {
     setStartTime(value);
-    // Only update the viewer state if it's a valid number
+
     const numValue = parseFloat(value);
-    if (!isNaN(numValue) && numValue >= 0 && numValue < timeRange[1]) {
-      viewerState.setVideoRecorderStartTime(numValue);
-      // Update slider
-      setTimeRange([numValue, timeRange[1]]);
+
+    if (
+      !isNaN(numValue) &&
+      numValue >= animationStartOffset &&
+      numValue < timeRange[1]
+    ) {
+      const roundedValue = numValue;
+      setTimeRange([roundedValue, timeRange[1]]);
+      viewerState.setVideoRecorderStartTime(roundedValue);
     }
   }
 
   const handleEndTimeChange = (value: string) => {
     setEndTime(value);
-    // Only update the viewer state if it's a valid number
+
     const numValue = parseFloat(value);
-    if (!isNaN(numValue) && numValue >= 0 && numValue > timeRange[0] && numValue <= maxTime) {
-      viewerState.setVideoRecorderEndTime(numValue);
-      // Update slider
-      setTimeRange([timeRange[0], numValue]);
+
+    if (
+      !isNaN(numValue) &&
+      numValue > timeRange[0] &&
+      numValue <= maxTime
+    ) {
+      const roundedValue = numValue;
+      setTimeRange([timeRange[0], roundedValue]);
+      viewerState.setVideoRecorderEndTime(roundedValue);
     }
   }
 
@@ -290,16 +299,23 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
 
   // Calculate slider marks based on maxTime
   const getSliderMarks = () => {
-    if (maxTime <= 5) {
+    const start = animationStartOffset;
+    const end = maxTime;
+    const range = end - start;
+
+    if (range <= 5) {
       return [
-        { value: 0, label: '0' },
-        { value: maxTime, label: `${maxTime.toFixed(1)}s` }
+        { value: start, label: `${start.toFixed(1)}s` },
+        { value: end, label: `${end.toFixed(1)}s` }
       ];
     }
+
+    const middle = start + range / 2;
+
     return [
-      { value: 0, label: '0' },
-      { value: Math.floor(maxTime / 2), label: `${Math.floor(maxTime / 2)}s` },
-      { value: maxTime, label: `${maxTime.toFixed(1)}s` }
+      { value: start, label: `${start.toFixed(1)}s` },
+      { value: middle, label: `${middle.toFixed(1)}s` },
+      { value: end, label: `${end.toFixed(1)}s` }
     ];
   };
 
@@ -408,7 +424,7 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
               value={loopsToRecord}
               size="small"
               onChange={(e) => handleLoopsChange(e.target.value)}
-              error={String(loopsToRecord) !== "" && !validateInteger(String(loopsToRecord))}
+              error={loopsToRecord !== "" && !validateInteger(loopsToRecord)}
               margin="dense"
             />
           </div>
@@ -435,7 +451,12 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
                 color: 'text.secondary',
                 marginBottom: '8px'
               }}>
-                Motion duration: {maxTime.toFixed(2)}s
+                Motion duration: {(maxTime - animationStartOffset).toFixed(1)}s
+                {animationStartOffset > 0 && (
+                  <div>
+                    Animation timeline: {animationStartOffset.toFixed(1)}s – {maxTime.toFixed(1)}s
+                  </div>
+                )}
               </div>
 
               {/* Dual-handle slider */}
@@ -445,10 +466,11 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
                   onChange={handleTimeRangeChange}
                   valueLabelDisplay="auto"
                   size="small"
-                  min={0}
+                  min={animationStartOffset}
                   max={maxTime}
                   step={0.1}
                   marks={getSliderMarks()}
+                  valueLabelFormat={(value) => `${value.toFixed(1)}s`}
                 />
               </div>
 
@@ -472,7 +494,6 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
                   placeholder="e.g., 5.0"
                   size="small"
                   error={endTime !== "" && !validateTimeFormat(endTime)}
-                  helperText={`Max: ${maxTime.toFixed(2)}s`}
                   margin="dense"
                 />
               </div>

--- a/src/components/Components/SnapShotModal.tsx
+++ b/src/components/Components/SnapShotModal.tsx
@@ -11,7 +11,8 @@ import {
   Select,
   MenuItem,
   InputLabel,
-  TextField
+  TextField,
+  InputAdornment
 } from '@mui/material';
 import React from 'react';
 import PhotoCameraTwoToneIcon from '@mui/icons-material/PhotoCameraTwoTone';
@@ -93,11 +94,45 @@ const SnapShotModal: React.FC<{open:boolean}> = () => {
     formData.transparent_background = event.currentTarget.checked?'true':'false';
     setChanged(!changed)
   };
-    const handleImageNameChange = (event:any) => {
-    curState.viewerState.setSnapshotName(event.target.value)
+  const getImageNameWithoutExtension = () => {
+    const currentName = curState.viewerState.snapshotName || "";
+    const extension = `.${formData.image_format}`;
+
+    if (currentName.toLowerCase().endsWith(extension.toLowerCase())) {
+      return currentName.slice(0, -extension.length);
+    }
+
+    const knownExtensions = imageFormats.map((format) => `.${format.value}`);
+    const existingExtension = knownExtensions.find((ext) =>
+      currentName.toLowerCase().endsWith(ext.toLowerCase())
+    );
+
+    if (existingExtension) {
+      return currentName.slice(0, -existingExtension.length);
+    }
+
+    return currentName;
   };
+
+  const handleImageNameChange = (event:any) => {
+    const nameWithoutExtension = event.target.value;
+    curState.viewerState.setSnapshotName(`${nameWithoutExtension}.${formData.image_format}`)
+  };
+
   const handleImageFormatChange = (event: any) => {
-    setFormData({ ...formData, image_format: event.target.value });
+    const newFormat = event.target.value;
+    const currentName = curState.viewerState.snapshotName || "";
+    const knownExtensions = imageFormats.map((format) => `.${format.value}`);
+    const existingExtension = knownExtensions.find((ext) =>
+      currentName.toLowerCase().endsWith(ext.toLowerCase())
+    );
+
+    const nameWithoutExtension = existingExtension
+      ? currentName.slice(0, -existingExtension.length)
+      : currentName;
+
+    setFormData({ ...formData, image_format: newFormat });
+    curState.viewerState.setSnapshotName(`${nameWithoutExtension}.${newFormat}`);
     setChanged(!changed)
   };
   const handleQualityLevelChange = (event: any) => {
@@ -181,9 +216,16 @@ const SnapShotModal: React.FC<{open:boolean}> = () => {
                   <TextField
                     size="small"
                     label={t('recordView.image_name_label')}
-                    value={curState.viewerState.snapshotName}
+                    value={getImageNameWithoutExtension()}
                     onChange={handleImageNameChange}
                     fullWidth
+                    InputProps={{
+                      endAdornment: (
+                        <InputAdornment position="end">
+                          .{formData.image_format}
+                        </InputAdornment>
+                      ),
+                    }}
                   />
                 </FormControl>
 

--- a/src/components/Components/VideoRecorder.tsx
+++ b/src/components/Components/VideoRecorder.tsx
@@ -682,8 +682,11 @@ function VideoRecorder(props: VideoRecorderViewProps) {
           return;
         }
 
-        if (endTime - startTime < 0.5) {
-          enqueueSnackbar('Recording duration must be at least 0.5 seconds', {
+        // Rounding to avoid floating point issues
+        const recordingDuration = Math.round((endTime - startTime) * 10) / 10;
+
+        if (recordingDuration < 0.1) {
+          enqueueSnackbar('Recording duration must be at least 0.1 seconds', {
             variant: 'warning',
             autoHideDuration: 5000
           });

--- a/src/components/Components/VideoRecorder.tsx
+++ b/src/components/Components/VideoRecorder.tsx
@@ -8,7 +8,7 @@ import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import { useModelContext } from "../../state/ModelUIStateContext";
 import { getTimestamp } from "../../helpers/timeHelpers";
-import {Color, WebGLRenderer} from 'three';
+import {WebGLRenderer} from 'three';
 import JSZip from 'jszip';
 import { SceneTreeSortableHandle } from "../Components/SceneTree/SceneTreeSortable"
 
@@ -928,7 +928,13 @@ function VideoRecorder(props: VideoRecorderViewProps) {
         }
 
         if (url) {
-          downloadFile(url, `${viewerState.recordedVideoName}_${timestamp}.${format}`);
+          // Format comes from video_name from the modal. So we have to insert the timestamp.
+          const fileExtension = `.${format}`;
+          const baseName = viewerState.recordedVideoName.endsWith(fileExtension)
+            ? viewerState.recordedVideoName.slice(0, -fileExtension.length)
+            : viewerState.recordedVideoName;
+
+          downloadFile(url, `${baseName}_${timestamp}${fileExtension}`);
           enqueueSnackbar(`Export successful: ${capturedFrames.current.length} frames`, {
             variant: 'success',
             autoHideDuration: 10000


### PR DESCRIPTION
Fixes #411. Specifically:

> (2) The "Trim Motion" option does not seem to work. First, it uses the original motion's start and end time, but rather starts the motion from 0 seconds and ends with the length of the motion. Second, in my example motion, the prepopulated end time was larger than the "max" time (rounding issue?). Finally, if the "Trim Motion" button is checked, no motion is recorded in the video.

For testing, I created a motion starting in 0.4 and checked that it correctly loads it independently of starting time, showing starting and ending times correctly and recording accordingly.

I also removed some unused variables/useEffects and tried to simplify the code.

This issue also resolves the issue with file names with no extension in mac, by inserting a decorator with the extension that is always appended to the name, independently of it being modified.

Additionally, video recorder settings are now only saved when "Save" is clicked, and discarded when clicking outside or clicking "Close".